### PR TITLE
[main@c32bba2] Update AL-Go System Files from microsoft/AL-Go-AppSource@main - 10e4662

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,5 @@
 {
   "type": "AppSource App",
   "templateUrl": "https://github.com/microsoft/AL-Go-AppSource@main",
-  "templateSha": "7f5ede0b71995e4082c3b16c7865984375f4b60f"
+  "templateSha": "10e466217258cbc3aedec799c01793295c8d5ecb"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,46 @@
+## v7.1
+
+### Issues
+
+- Issue 1678 Test summary is showing too many status icons
+- Issue 1640 AL1040 error due to app folder within the artifacts cache being incorrectly recognized as an app folder
+- Issue 1630 Error when downloading a release, when the destination folder already exists.
+- Issue 1540 and 1649 Apps with dependencies to Microsft\_\_EXCLUDE\_ apps fails deployment
+- Issue 1547 Dependencies will be installed even if DependencyInstallMode is ignore, but dependencies will never be installed on production environments
+- Issue 1654 GithubPackageContext does not work together with private trustedNuGetFeeds
+- Issue 1627 AL-Go should throw an error or a warning if you create a release, which is older than the latest release
+- Issue 1657 When no files modified on Git, deployment fails
+- Issue 1530 Dependency Field Service Integration does not get published in container while Installing apps
+- Issue 1644 Support for AppAuth when using a private Template repository from another organization
+- Issue 1669 GitHub App authentication to download dependencies from private repositories
+- Issue 1478 Rate Limit Exceeded when running Update AL-Go System files
+
+## v7.0
+
+### Issues
+
+- Issue 1519 Submitting to AppSource WARNING: AuthContext.Scopes is .. should be
+- Issue 1521 Dependencies not installed for multi project incremental PR build
+- Issue 1522 Strange warnings in Deploy job post update to AL-Go 6.4
+- BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
+- Issue 1526 When updating AL-Go system files, the update process (creating a PR or directly pushing to the branch) fails when there is a file or directory in the repo with the same name as the branch that is to be updated
+- Legacy code signing stopped working
+
+### Page Scripting visualizer
+
+Page scripting tests have been available for AL-Go for GitHub for a while but required manual inspection of the Page scripting artifact to see the results. It is now possible to get a quick overview in the job summary section of a CICD build, similar to how regular and bcpt test results are displayed.
+
+No new settings are required. Test results will automatically be displayed if tests are enabled via the existing setting [pageScriptingTests](https://aka.ms/algosettings#pageScriptingTests).
+
+### Support for deploying to sandbox environments from a pull request
+
+AL-Go for GitHub now supports deploying from a PR. When using the 'Publish To Environment' workflow, it is now possible to input 'PR_X' as the App version, where 'X' is the PR Id. This will deploy the artifacts from the latest PR build to the chosen environment, if that build is completed and successful.
+
+All apps, which were not built by the PR build will be deployed from the last known good build. You can find a notification on the PR build explaining which build is used as the last known good build.
+
+> [!NOTE]
+> When deploying a PR build to a sandbox environment, the app will get a special version number, which is: major.minor.maxint.run-number. This means that the sandbox environment likely needs to be deleted after the testing has ended.
+
 ## v6.4
 
 ### Deprecations

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -50,18 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,7 +69,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v6.4
+        uses: microsoft/AL-Go-Actions/AddExistingApp@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -48,7 +48,7 @@ jobs:
       powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -59,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -73,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
         with:
           shell: pwsh
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,21 +149,23 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v6.4
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: pwsh
           templateUrl: ${{ env.templateUrl }}
@@ -212,12 +214,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
@@ -226,7 +228,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v6.4
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
         with:
           shell: pwsh
           artifacts: '.artifacts'
@@ -258,12 +260,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -277,7 +279,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -285,7 +287,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v6.4
+        uses: microsoft/AL-Go-Actions/Deploy@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -297,7 +299,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v6.4
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -320,25 +322,25 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v6.4
+        uses: microsoft/AL-Go-Actions/Deliver@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -358,7 +360,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -60,19 +60,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -80,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v6.4
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -50,7 +50,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -59,19 +59,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -90,7 +90,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -112,13 +112,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -137,7 +137,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v6.4
+        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -66,18 +66,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -85,7 +85,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v6.4
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -7,8 +7,8 @@ concurrency:
 on:
   workflow_dispatch:
     inputs:
-      appVersion:
-        description: App version to promote to release (default is latest)
+      buildVersion:
+        description: Build version to promote to release (default is latest)
         required: false
         default: 'latest'
       name:
@@ -78,7 +78,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -87,20 +87,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: templateUrl,repoName,type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -109,12 +109,12 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v6.4
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
         with:
           shell: pwsh
           templateUrl: ${{ env.templateUrl }}
@@ -124,7 +124,7 @@ jobs:
       - name: Analyze Artifacts
         id: analyzeartifacts
         env:
-          _appVersion: ${{ github.event.inputs.appVersion }}
+          _buildVersion: ${{ github.event.inputs.buildVersion }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $projects = '${{ steps.determineProjects.outputs.ProjectsJson }}' | ConvertFrom-Json
@@ -162,14 +162,14 @@ jobs:
             }
             $refname = "$ENV:GITHUB_REF_NAME".Replace('/','_')
             Write-Host "Analyzing artifacts for project $project"
-            $appVersion = "$env:_appVersion"
-            if ($appVersion -eq "latest") {
+            $buildVersion = "$env:_buildVersion"
+            if ($buildVersion -eq "latest") {
               Write-Host "Grab latest"
               $artifact = $allArtifacts | Where-Object { $_.name -like "$project-$refname-Apps-*.*.*.*" -or $_.name -like "$project-$refname-PowerPlatformSolution-*.*.*.*" } | Select-Object -First 1
             }
             else {
-              Write-Host "Search for $project-$refname-Apps-$appVersion or $project-$refname-PowerPlatformSolution-$appVersion"
-              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$appVersion"-or $_.name -eq "$project-$refname-PowerPlatformSolution-$appVersion" } | Select-Object -First 1
+              Write-Host "Search for $project-$refname-Apps-$buildVersion or $project-$refname-PowerPlatformSolution-$buildVersion"
+              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$buildVersion"-or $_.name -eq "$project-$refname-PowerPlatformSolution-$buildVersion" } | Select-Object -First 1
             }
             if ($artifact) {
               $startIndex = $artifact.name.LastIndexOf('-') + 1
@@ -209,9 +209,10 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v6.4
+        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v7.1
         with:
           shell: pwsh
+          buildVersion: ${{ github.event.inputs.buildVersion }}
           tag_name: ${{ github.event.inputs.tag }}
           target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 
@@ -251,13 +252,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -295,7 +296,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v6.4
+        uses: microsoft/AL-Go-Actions/Deliver@v7.1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -304,11 +305,11 @@ jobs:
           type: 'Release'
           projects: ${{ matrix.project }}
           deliveryTarget: 'NuGet'
-          artifacts: ${{ github.event.inputs.appVersion }}
+          artifacts: ${{ github.event.inputs.buildVersion }}
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v6.4
+        uses: microsoft/AL-Go-Actions/Deliver@v7.1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -317,7 +318,7 @@ jobs:
           type: 'Release'
           projects: ${{ matrix.project }}
           deliveryTarget: 'Storage'
-          artifacts: ${{ github.event.inputs.appVersion }}
+          artifacts: ${{ github.event.inputs.buildVersion }}
           atypes: 'Apps,TestApps,Dependencies'
 
   CreateReleaseBranch:
@@ -352,13 +353,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -366,7 +367,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v6.4
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -384,7 +385,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -62,18 +62,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -81,7 +81,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v6.4
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -30,7 +30,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -41,13 +41,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -55,7 +55,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v6.4
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
         with:
           shell: pwsh
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -45,7 +45,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -54,18 +54,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +73,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v6.4
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PublishToAppSource.yaml
+++ b/.github/workflows/PublishToAppSource.yaml
@@ -38,7 +38,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
@@ -60,20 +60,20 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'appSourceContext'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v6.4
+        uses: microsoft/AL-Go-Actions/Deliver@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       appVersion:
-        description: App version to deploy to environment(s) (current, prerelease, draft, latest or version number)
+        description: App version to deploy to environment(s) (current, prerelease, draft, latest, version number or PR_<PR Id>)
         required: false
         default: 'current'
       environmentName:
@@ -36,7 +36,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -45,19 +45,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: pwsh
@@ -107,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.4/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -141,21 +141,21 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Get Artifacts for deployment
-        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v6.4
+        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v7.1
         with:
           shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v6.4
+        uses: microsoft/AL-Go-Actions/Deploy@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -172,10 +172,11 @@ jobs:
           artifactsFolder: '.artifacts'
           type: 'Publish'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
+          artifactsVersion: ${{ github.event.inputs.appVersion }}
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v6.4
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -194,7 +195,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v6.4
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v7.1
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -57,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: shortLivedArtifactsRetentionDays
@@ -76,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v6.4
+        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -122,7 +122,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go-Actions/Troubleshooting@v6.4
+        uses: microsoft/AL-Go-Actions/Troubleshooting@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: templateUrl
 
       - name: Get Workflow Multi-Run Branches
         id: GetBranches
-        uses: microsoft/AL-Go-Actions/GetWorkflowMultiRunBranches@v6.4
+        uses: microsoft/AL-Go-Actions/GetWorkflowMultiRunBranches@v7.1
         with:
           shell: pwsh
           includeBranches: ${{ github.event.inputs.includeBranches }}
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.4
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
         with:
           shell: pwsh
 
@@ -95,19 +95,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: pwsh
           get: commitOptions
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -134,7 +134,9 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v6.4
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: pwsh
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -146,7 +148,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.4
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -99,16 +99,16 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
           buildMode: ${{ inputs.buildMode }}
-          get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact,trustedSigning,useGitSubmodules
+          get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,doNotRunBcptTests,doNotRunpageScriptingTests,artifact,generateDependencyArtifact,trustedSigning,useGitSubmodules
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go-Actions/DetermineBuildProject@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineBuildProject@v7.1
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -118,7 +118,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.4
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,22 +136,22 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v6.4
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v7.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cache Business Central Artifacts
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: .artifactcache
+          path: ${{ runner.temp }}/.artifactcache
           key: ${{ env.artifactCacheKey }}
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v6.4
+        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v7.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -162,7 +162,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go-Actions/RunPipeline@v6.4
+        uses: microsoft/AL-Go-Actions/RunPipeline@v7.1
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -180,7 +180,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
-        uses: microsoft/AL-Go-Actions/Sign@v6.4
+        uses: microsoft/AL-Go-Actions/Sign@v7.1
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v6.4
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v7.1
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -197,7 +197,7 @@ jobs:
           suffix: ${{ inputs.artifactsNameSuffix }}
 
       - name: Publish artifacts - apps
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/Apps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
@@ -206,7 +206,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - dependencies
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: inputs.artifactsRetentionDays >= 0 && env.generateDependencyArtifact == 'True' && (hashFiles(format('{0}/.buildartifacts/Dependencies/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
@@ -215,7 +215,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - test apps
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/TestApps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
@@ -224,7 +224,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - build output
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
@@ -232,7 +232,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
@@ -240,7 +240,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - test results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
@@ -248,7 +248,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
@@ -256,7 +256,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultsArtifactsName }}
@@ -264,7 +264,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test result details
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResultDetails/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultDetailsArtifactsName }}
@@ -274,14 +274,33 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v6.4
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
+          testType: "normal"
+
+      - name: Analyze BCPT Test Results
+        id: analyzeTestResultsBCPT
+        if: (success() || failure()) && env.doNotRunBcptTests == 'False'
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          testType: "bcpt"
+
+      - name: Analyze Page Scripting Test Results
+        id: analyzeTestResultsPageScripting
+        if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          testType: "pageScripting"
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v6.4
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@v7.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}


### PR DESCRIPTION
## v7.1

### Issues

- Issue 1678 Test summary is showing too many status icons
- Issue 1640 AL1040 error due to app folder within the artifacts cache being incorrectly recognized as an app folder
- Issue 1630 Error when downloading a release, when the destination folder already exists.
- Issue 1540 and 1649 Apps with dependencies to Microsft\_\_EXCLUDE\_ apps fails deployment
- Issue 1547 Dependencies will be installed even if DependencyInstallMode is ignore, but dependencies will never be installed on production environments
- Issue 1654 GithubPackageContext does not work together with private trustedNuGetFeeds
- Issue 1627 AL-Go should throw an error or a warning if you create a release, which is older than the latest release
- Issue 1657 When no files modified on Git, deployment fails
- Issue 1530 Dependency Field Service Integration does not get published in container while Installing apps
- Issue 1644 Support for AppAuth when using a private Template repository from another organization
- Issue 1669 GitHub App authentication to download dependencies from private repositories
- Issue 1478 Rate Limit Exceeded when running Update AL-Go System files

## v7.0

### Issues

- Issue 1519 Submitting to AppSource WARNING: AuthContext.Scopes is .. should be
- Issue 1521 Dependencies not installed for multi project incremental PR build
- Issue 1522 Strange warnings in Deploy job post update to AL-Go 6.4
- BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
- Issue 1526 When updating AL-Go system files, the update process (creating a PR or directly pushing to the branch) fails when there is a file or directory in the repo with the same name as the branch that is to be updated
- Legacy code signing stopped working

### Page Scripting visualizer

Page scripting tests have been available for AL-Go for GitHub for a while but required manual inspection of the Page scripting artifact to see the results. It is now possible to get a quick overview in the job summary section of a CICD build, similar to how regular and bcpt test results are displayed.

No new settings are required. Test results will automatically be displayed if tests are enabled via the existing setting [pageScriptingTests](https://aka.ms/algosettings#pageScriptingTests).

### Support for deploying to sandbox environments from a pull request

AL-Go for GitHub now supports deploying from a PR. When using the 'Publish To Environment' workflow, it is now possible to input 'PR_X' as the App version, where 'X' is the PR Id. This will deploy the artifacts from the latest PR build to the chosen environment, if that build is completed and successful.

All apps, which were not built by the PR build will be deployed from the last known good build. You can find a notification on the PR build explaining which build is used as the last known good build.

> [!NOTE]
> When deploying a PR build to a sandbox environment, the app will get a special version number, which is: major.minor.maxint.run-number. This means that the sandbox environment likely needs to be deleted after the testing has ended.
