### PR TITLE
Chore: code cleanup and minor refactoring

### DIFF
--- a/SBIDataBraider_APP/src/.enums/SPBDBraiderBufferType.Enum.al
+++ b/SBIDataBraider_APP/src/.enums/SPBDBraiderBufferType.Enum.al
@@ -4,7 +4,7 @@ enum 71033610 "SPB DBraider Buffer Type"
 
     value(0; " ")
     {
-        Caption = ' ';
+        Caption = ' ', Locked = true;
     }
     value(1; Direct)
     {

--- a/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderManager.PermissionSet.al
+++ b/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderManager.PermissionSet.al
@@ -1,8 +1,9 @@
 permissionset 71033600 "SPB DBraider Manager"
 {
     Assignable = true;
-    Caption = 'DataBraider Manager';
-    Permissions = tabledata "SPB DBraider Setup" = RIMD,
+    Caption = 'DataBraider Manager', MaxLength = 30;
+    Permissions =
+        tabledata "SPB DBraider Setup" = RIMD,
         tabledata "SPB DBraider Config. Header" = RIMD,
         tabledata "SPB DBraider Config. Line" = RIMD,
         tabledata "SPB DBraider ConfLine Field" = RIMD,

--- a/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderUser.PermissionSet.al
+++ b/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderUser.PermissionSet.al
@@ -1,8 +1,7 @@
 permissionset 71033601 "SPB DBraider User"
 {
     Assignable = true;
-    Caption = 'DataBraider User';
-
+    Caption = 'DataBraider User', MaxLength = 30;
     Permissions =
         tabledata "SPB DBraider Setup" = R,
         tabledata "SPB DBraider Config. Header" = R,

--- a/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Page.al
+++ b/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Page.al
@@ -113,7 +113,7 @@ page 71033600 "SPB DBraider Setup"
                 Promoted = true;
                 PromotedCategory = Process;
                 PromotedIsBig = true;
-                RunObject = Page "SPB Create Endpoints";
+                RunObject = page "SPB Create Endpoints";
                 ToolTip = 'This function will setup the Business Central standard endpoints.';
             }
             action(UpdateFieldCaptions)
@@ -144,7 +144,7 @@ page 71033600 "SPB DBraider Setup"
                 Promoted = true;
                 PromotedCategory = Process;
                 PromotedIsBig = true;
-                RunObject = Page "SPB DBraider Variables";
+                RunObject = page "SPB DBraider Variables";
                 ToolTip = 'This function will open the Variables page.';
 
             }

--- a/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Table.al
+++ b/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Table.al
@@ -10,12 +10,10 @@ table 71033600 "SPB DBraider Setup"
         field(1; "Primary Key"; Code[10])
         {
             Caption = 'Primary Key';
-            DataClassification = SystemMetadata;
         }
         field(5; EnabledGlobally; Boolean)
         {
             Caption = 'Enabled Globally';
-            DataClassification = SystemMetadata;
             InitValue = true;
         }
         field(10; "Default Page Size"; Integer)
@@ -27,31 +25,26 @@ table 71033600 "SPB DBraider Setup"
         field(30; "Hide ROI Panel"; Boolean)
         {
             Caption = 'Hide ROI Panel';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(60; "Disable Auto ModifiedAt"; Boolean)
         {
             Caption = 'Disable Auto ModifiedAt';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(61; "Disable Auto SystemId"; Boolean)
         {
             Caption = 'Disable Auto SystemId';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(70; "Disable Auto-List"; Boolean)
         {
             Caption = 'Disable Auto-List';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(80; "Disable Related Id"; Boolean)
         {
             Caption = 'Disable Related Id';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
     }

--- a/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Table.al
+++ b/SBIDataBraider_APP/src/.setup/SPBDBraiderSetup.Table.al
@@ -10,6 +10,7 @@ table 71033600 "SPB DBraider Setup"
         field(1; "Primary Key"; Code[10])
         {
             Caption = 'Primary Key';
+            NotBlank = false;
         }
         field(5; EnabledGlobally; Boolean)
         {

--- a/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
+++ b/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
@@ -3,7 +3,6 @@ page 71033609 "SPB DBraider API JSON"
     APIGroup = 'databraider';
     APIPublisher = 'sparebrained';
     APIVersion = 'v2.0';
-    ApplicationArea = All;
     Caption = 'Data Braider Read API';
     DelayedInsert = true;
     EntityName = 'read';

--- a/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
+++ b/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
@@ -70,15 +70,15 @@ page 71033609 "SPB DBraider API JSON"
     begin
         Licensed := LicenseConnector.CheckIfActive(false);
         CheckIfGloballyEnbled();
-        if not Rec.IsTemporary and GuiAllowed then
+        if not Rec.IsTemporary() and GuiAllowed() then
             Error(TempRecOnlyErr);
-        if FilterJsonArray.Count <> 0 then
+        if FilterJsonArray.Count() <> 0 then
             Rec.Insert();
     end;
 
     trigger OnFindRecord(Which: Text): Boolean   //GET
     begin
-        if not Rec.IsTemporary and GuiAllowed then
+        if not Rec.IsTemporary() and GuiAllowed() then
             Error(TempRecOnlyErr);
 
         if Licensed then begin
@@ -143,7 +143,7 @@ page 71033609 "SPB DBraider API JSON"
             Rec.DeleteAll();
             Rec.TransferFields(DBraiderConfig);
             // Apply any filters sent in via API
-            if FilterJsonArray.Count > 0 then
+            if FilterJsonArray.Count() > 0 then
                 DBraiderEngine.BuildFiltersFromJson(DBraiderConfig.Code, FilterJsonArray);
             if FilterJson <> '' then
                 DBraiderEngine.SetFilterJson(FilterJson);  // Passing this along for eventing

--- a/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
+++ b/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderAPIJSON.Page.al
@@ -139,7 +139,7 @@ page 71033609 "SPB DBraider API JSON"
         DBraiderConfig.SetRange(Enabled, true);
         Rec.Reset();
         if DBraiderConfig.FindFirst() then begin  // Intentional: You can only get one result set, so findfirst.  If they filter on a range, first only!
-                                                  //if DBraiderConfig.Get(rec.Code) then begin
+                                                  //if DBraiderConfig.Get(Rec.Code) then begin
             Rec.DeleteAll();
             Rec.TransferFields(DBraiderConfig);
             // Apply any filters sent in via API

--- a/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderWriteAPI.Page.al
+++ b/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderWriteAPI.Page.al
@@ -54,7 +54,7 @@ page 71033611 "SPB DBraider Write API"
         LicenseConnector: Codeunit "SPB DBraider Licensing";
     begin
         Licensed := LicenseConnector.CheckIfActive(false);
-        if not Rec.IsTemporary and GuiAllowed then
+        if not Rec.IsTemporary() and GuiAllowed() then
             Error(TempRecOnlyErr);
     end;
 

--- a/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderWriteAPI.Page.al
+++ b/SBIDataBraider_APP/src/API-Endpoints/SPBDBraiderWriteAPI.Page.al
@@ -3,7 +3,6 @@ page 71033611 "SPB DBraider Write API"
     APIGroup = 'databraider';
     APIPublisher = 'sparebrained';
     APIVersion = 'v2.0';
-    ApplicationArea = All;
     Caption = 'Data Braider Write API';
     DelayedInsert = true;
     EntityName = 'write';

--- a/SBIDataBraider_APP/src/BC_Operations/SPBDBraiderTelemetry.Codeunit.al
+++ b/SBIDataBraider_APP/src/BC_Operations/SPBDBraiderTelemetry.Codeunit.al
@@ -62,7 +62,7 @@ codeunit 71033609 "SPB DBraider Telemetry"
 
 
     #region UsageStats
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Telemetry Management", 'OnSendDailyTelemetry', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Telemetry Management", OnSendDailyTelemetry, '', true, true)]
     local procedure SendDailyTelemetry()
     begin
         SendActivityTelemetry(true);

--- a/SBIDataBraider_APP/src/BC_Operations/SPBDBraiderTelemetry.Codeunit.al
+++ b/SBIDataBraider_APP/src/BC_Operations/SPBDBraiderTelemetry.Codeunit.al
@@ -96,20 +96,20 @@ codeunit 71033609 "SPB DBraider Telemetry"
         if not DailySend then begin
             if IsolatedStorage.Get('DataBraider-Telementry', DataScope::Module, LastTelemetrySentDateText) then
                 if Evaluate(LastTelemetrySentDate, LastTelemetrySentDateText) then;
-            if (CurrentDateTime - LastTelemetrySentDate) < (24 * 60 * 60 * 1000) then
+            if (CurrentDateTime() - LastTelemetrySentDate) < (24 * 60 * 60 * 1000) then
                 exit;
         end else
-            LastTelemetrySentDate := CurrentDateTime - (24 * 60 * 60 * 1000);
+            LastTelemetrySentDate := CurrentDateTime() - (24 * 60 * 60 * 1000);
 
         // Braider Usage Info
 
         // # of Read Endpoints Configured
         SPBDBraiderConfigHeader.SetRange("Endpoint Type", Enum::"SPB DBraider Endpoint Type"::"Read Only");
-        EmitTraceTag(ReadEndpointsLbl, SPBDBraiderConfigHeader.Count, 'SPB0101');
+        EmitTraceTag(ReadEndpointsLbl, SPBDBraiderConfigHeader.Count(), 'SPB0101');
 
         // # of Write Single Endpoints Configured
         SPBDBraiderConfigHeader.SetRange("Endpoint Type", Enum::"SPB DBraider Endpoint Type"::"Per Record");
-        EmitTraceTag(WriteSingleEndpointsLbl, SPBDBraiderConfigHeader.Count, 'SPB0102');
+        EmitTraceTag(WriteSingleEndpointsLbl, SPBDBraiderConfigHeader.Count(), 'SPB0102');
 
         SPBDBraiderUtilities.GetTelemetryFigures(Results);
         // # Avg Reads per Endpoint (CM)
@@ -165,10 +165,10 @@ codeunit 71033609 "SPB DBraider Telemetry"
         // User/Company/DB info
         // # of Active Users in DB
         Users.SetRange(State, Users.State::Enabled);
-        EmitTraceTag(DBActiveUsersLbl, Users.Count, 'SPB0120');
+        EmitTraceTag(DBActiveUsersLbl, Users.Count(), 'SPB0120');
 
         // # of Companies in DB
-        EmitTraceTag(DBCompaniesLbl, CompanyRec.Count, 'SPB0121');
+        EmitTraceTag(DBCompaniesLbl, CompanyRec.Count(), 'SPB0121');
 
         IsolatedStorage.Set('DataBraider-Telemetry', Format(LastTelemetrySentDate, 0, 9), DataScope::Module);
     end;
@@ -184,7 +184,7 @@ codeunit 71033609 "SPB DBraider Telemetry"
         TraceTagMessage := StrSubstNo(TraceTagTelemetryMsg, FeatureName, FeatureCount);
         TelemetryDimension.Add(CustomFeatureCountLbl, Format(FeatureCount));
         //TODO: When MS will add the company name to log message this can be obsoleted
-        TelemetryDimension.Add(CustomCompanyNameLbl, CompanyName);
+        TelemetryDimension.Add(CustomCompanyNameLbl, CompanyName());
         Session.LogMessage(Tag, TraceTagMessage, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, TelemetryDimension);
     end;
 
@@ -259,14 +259,14 @@ codeunit 71033609 "SPB DBraider Telemetry"
         thisValue: Text;
     begin
         TraceTagMessage := StrSubstNo(TraceTagTelemetryMsg, DBHeader.Code, EventName);
-        TelemetryDimension.Add(CustomCompanyNameLbl, CompanyName);
+        TelemetryDimension.Add(CustomCompanyNameLbl, CompanyName());
         TelemetryDimension.Add(EndpointCodeLbl, DBHeader.Code);
         TelemetryDimension.Add(EndpointTypeLbl, Format(DBHeader."Endpoint Type"));
         if DBHeader."Emit Telemetry Include Body" then
             TelemetryDimension.Add('Body', RawContent);
-        if ExtraDimensions.Count > 0 then
-            for i := 1 to ExtraDimensions.Count do begin
-                thisKey := ExtraDimensions.Keys.Get(i);
+        if ExtraDimensions.Count() > 0 then
+            for i := 1 to ExtraDimensions.Count() do begin
+                thisKey := ExtraDimensions.Keys().Get(i);
                 thisValue := ExtraDimensions.Get(thisKey);
                 TelemetryDimension.Add(thisKey, thisValue);
             end;

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenAutomate.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenAutomate.Codeunit.al
@@ -297,7 +297,7 @@ codeunit 71033622 "SPB DBraider Gen Automate"
                     ResultBuilder.AppendLine('                }')
             until SPBDBraiderConfigLine.Next() < 1;
 
-        ResultBuilder.Remove(ResultBuilder.Length - 1, 1); // Remove that last comma
+        ResultBuilder.Remove(ResultBuilder.Length() - 1, 1); // Remove that last comma
         ResultBuilder.AppendLine('              }');
         ResultBuilder.AppendLine('            }');
         ResultBuilder.AppendLine('          }');

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenPostman.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenPostman.Codeunit.al
@@ -398,7 +398,7 @@ codeunit 71033617 "SPB DBraider Gen. Postman"
         OptionsObj: JsonObject;
         UrlObj: JsonObject;
     begin
-        TemplateBuilder.Append(StrSubstNo(Actionlbl, ChangeAction));
+        TemplateBuilder.Append(StrSubstNo(ActionLbl, ChangeAction));
         if SPBDBraiderConfLineFields.FindSet() then
             repeat
                 case SPBDBraiderConfLineFields."Field Type" of

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenPowerBI.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenPowerBI.Codeunit.al
@@ -81,17 +81,17 @@ in
                     until SPBDBraiderConfLineField.Next() < 1;
             until SPBDBraiderConfLine.Next() < 1;
 
-        for i := 1 to FromName.Count do begin
+        for i := 1 to FromName.Count() do begin
             FieldList := FieldList + '"' + FromName.Get(i) + '"';
-            if i < FromName.Count then
+            if i < FromName.Count() then
                 FieldList := FieldList + ', ';
         end;
         ResultBuilder.AppendLine('    #"Expanded ' + Rec.Description + '" = Table.ExpandRecordColumn(#"Converted to Table", "Column1", {' + FieldList + '}),');
 
         // For i to FromName.Count do, also get the ToName of the same index, and then Add the FromName and ToName to the FieldMappingList in the format of {"FromName", "ToName"},
-        for i := 1 to FromName.Count do begin
+        for i := 1 to FromName.Count() do begin
             FieldMappingList := FieldMappingList + '{"' + FromName.Get(i) + '", "' + ToName.Get(i) + '"}';
-            if i < FromName.Count then
+            if i < FromName.Count() then
                 FieldMappingList := FieldMappingList + ', ';
         end;
 

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfFieldAdv.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfFieldAdv.Page.al
@@ -8,7 +8,7 @@ page 71033621 "SPB DBraider Conf Field Adv"
 
     layout
     {
-        area(content)
+        area(Content)
         {
             group(Information)
             {

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
@@ -79,10 +79,11 @@ table 71033603 "SPB DBraider ConfLine Field"
 
             trigger OnValidate()
             var
+                ConfirmManagement: Codeunit "Confirm Management";
                 DisableAllCautionMsg: Label 'Using the ''Disable All'' option will disable all validation on this field. This can introduce dangerously malformed data and can result in significant expensive problems. Any damages from use of this function are your responsibility.\ \Are you CERTAIN you want to do this?';
             begin
                 if "Disable Validation" = "Disable Validation"::DisableAll then
-                    if not Confirm(DisableAllCautionMsg) then
+                    if not ConfirmManagement.GetResponseOrDefault(DisableAllCautionMsg, false) then
                         "Disable Validation" := "Disable Validation"::" "
             end;
         }
@@ -337,10 +338,11 @@ table 71033603 "SPB DBraider ConfLine Field"
     procedure RemoveInvalidFields()
     var
         DBraiderConfLineFieldSBI: Record "SPB DBraider ConfLine Field";
+        ConfirmManagement: Codeunit "Confirm Management";
         RecRef: RecordRef;
         ConfirmRemovalMsg: Label 'This will remove all fields that are no longer in the source table.  Are you sure you want to do this?';
     begin
-        if Confirm(ConfirmRemovalMsg, true) then begin
+        if ConfirmManagement.GetResponseOrDefault(ConfirmRemovalMsg, true) then begin
             DBraiderConfLineFieldSBI.CopyFilters(Rec);
             if DBraiderConfLineFieldSBI.FindSet() then begin
                 RecRef.Open(DBraiderConfLineFieldSBI."Table No.");

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
@@ -47,7 +47,6 @@ table 71033603 "SPB DBraider ConfLine Field"
         field(30; "Filter"; Text[250])
         {
             Caption = 'Filter';
-            DataClassification = SystemMetadata;
 
             trigger OnValidate()
             begin
@@ -127,7 +126,6 @@ table 71033603 "SPB DBraider ConfLine Field"
         field(130; "Primary Key"; Boolean)
         {
             Caption = 'Primary Key';
-            DataClassification = SystemMetadata;
             Description = 'Denotes if a field is part of the primary key';
             Editable = false;
         }

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
@@ -255,8 +255,8 @@ table 71033603 "SPB DBraider ConfLine Field"
         if Rec."Table No." <> 0 then begin
             RecRef.Open(Rec."Table No.");
             FieldsRef := RecRef.Field(FieldNo);
-            Rec."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type);
-            Rec."Field Class" := Format(FieldsRef.Class);
+            Rec."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type());
+            Rec."Field Class" := Format(FieldsRef.Class());
         end;
     end;
 
@@ -291,18 +291,18 @@ table 71033603 "SPB DBraider ConfLine Field"
             // Populate the dataset
             RecRef.Open("Table No.");
             PKFieldNumbers := SPBDBraiderUtilities.GetPrimaryKeyFields(RecRef);
-            for i := 1 to RecRef.FieldCount do begin
+            for i := 1 to RecRef.FieldCount() do begin
                 FieldsRef := RecRef.FieldIndex(i);
-                if not DBraiderConfLineFieldSBI2.Get(Rec."Config. Code", Rec."Config. Line No.", FieldsRef.Number) then begin
+                if not DBraiderConfLineFieldSBI2.Get(Rec."Config. Code", Rec."Config. Line No.", FieldsRef.Number()) then begin
                     DBraiderConfLineFieldSBI.Init();
                     DBraiderConfLineFieldSBI."Config. Code" := Rec."Config. Code";
                     DBraiderConfLineFieldSBI."Config. Line No." := Rec."Config. Line No.";
-                    DBraiderConfLineFieldSBI."Field No." := FieldsRef.Number;
+                    DBraiderConfLineFieldSBI."Field No." := FieldsRef.Number();
                     DBraiderConfLineFieldSBI."Table No." := Rec."Table No.";
                     DBraiderConfLineFieldSBI."Processing Order" := 10;
-                    DBraiderConfLineFieldSBI."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type);
-                    DBraiderConfLineFieldSBI."Field Class" := Format(FieldsRef.Class);
-                    DBraiderConfLineFieldSBI."Primary Key" := PKFieldNumbers.Contains(FieldsRef.Number);
+                    DBraiderConfLineFieldSBI."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type());
+                    DBraiderConfLineFieldSBI."Field Class" := Format(FieldsRef.Class());
+                    DBraiderConfLineFieldSBI."Primary Key" := PKFieldNumbers.Contains(FieldsRef.Number());
                     DBraiderConfLineFieldSBI.CalcFields("Field Name", Caption);
                     DBraiderConfLineFieldSBI."Fixed Field Name" := DBraiderConfLineFieldSBI."Field Name";
                     DBraiderConfLineFieldSBI."Fixed Field Caption" := DBraiderConfLineFieldSBI.Caption;
@@ -321,7 +321,7 @@ table 71033603 "SPB DBraider ConfLine Field"
                 if not RecRef.FieldExist(DBraiderConfLineFieldSBI2."Field No.") then begin
                     TempErrorMessage.Init();
                     TempErrorMessage.ID := DBraiderConfLineFieldSBI2."Field No.";
-                    TempErrorMessage."Table Name" := CopyStr(RecRef.Name, 1, MaxStrLen(TempErrorMessage."Table Name"));
+                    TempErrorMessage."Table Name" := CopyStr(RecRef.Name(), 1, MaxStrLen(TempErrorMessage."Table Name"));
                     TempErrorMessage."Table Number" := DBraiderConfLineFieldSBI2."Table No.";
                     TempErrorMessage."Field Name" := CopyStr(DBraiderConfLineFieldSBI2."Fixed Field Name", 1, MaxStrLen(TempErrorMessage."Field Name"));
                     TempErrorMessage."Field Number" := DBraiderConfLineFieldSBI2."Field No.";
@@ -330,7 +330,7 @@ table 71033603 "SPB DBraider ConfLine Field"
                     TempErrorMessage.Insert();
                 end;
             until DBraiderConfLineFieldSBI2.Next() = 0;
-        if not TempErrorMessage.IsEmpty then
+        if not TempErrorMessage.IsEmpty() then
             Page.RunModal(Page::"Error Messages", TempErrorMessage);
     end;
 

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineFlow.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineFlow.Table.al
@@ -153,10 +153,10 @@ table 71033610 "SPB DBraider ConfLine Flow"
         until NothingFound;
 
         // Now all the 'Possible Parents' are marked, so we can present that sub-list to the user
-        for i := 1 to PossibleValidParentTableNos.Count do begin
+        for i := 1 to PossibleValidParentTableNos.Count() do begin
             PossibleValidParentTableNos.Get(i, PossibleTableNo);
             PossibleValidTableFilterBuilder.Append(Format(PossibleTableNo));
-            if i < PossibleValidParentTableNos.Count then
+            if i < PossibleValidParentTableNos.Count() then
                 PossibleValidTableFilterBuilder.Append('|');
         end;
         AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineRelation.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineRelation.Table.al
@@ -7,27 +7,23 @@ table 71033604 "SPB DBraider ConfLine Relation"
         field(1; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header".Code;
         }
         field(2; "Config. Line No."; Integer)
         {
             Caption = 'Line No.';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Line"."Line No." where("Config. Code" = field("Config. Code"));
         }
 
         field(5; "Relation Line No."; Integer)
         {
             Caption = 'Field No.';
-            DataClassification = SystemMetadata;
         }
 
 
         field(10; "Parent Table"; Integer)
         {
             Caption = 'Parent Table';
-            DataClassification = SystemMetadata;
             Editable = false;
         }
         field(11; "Parent Table Name"; Text[30])
@@ -41,7 +37,6 @@ table 71033604 "SPB DBraider ConfLine Relation"
         field(20; "Child Table"; Integer)
         {
             Caption = 'Child Table';
-            DataClassification = SystemMetadata;
             Editable = false;
         }
         field(21; "Child Table Name"; Text[30])
@@ -55,7 +50,6 @@ table 71033604 "SPB DBraider ConfLine Relation"
         field(50; "Parent Field No."; Integer)
         {
             Caption = 'Parent Field';
-            DataClassification = SystemMetadata;
             TableRelation = Field."No." where(TableNo = field("Parent Table"));
 
             trigger OnValidate()
@@ -80,7 +74,6 @@ table 71033604 "SPB DBraider ConfLine Relation"
         field(70; "Child Field No."; Integer)
         {
             Caption = 'Child Field';
-            DataClassification = SystemMetadata;
             TableRelation = Field."No." where(TableNo = field("Child Table"));
 
             trigger OnValidate()
@@ -105,7 +98,6 @@ table 71033604 "SPB DBraider ConfLine Relation"
         field(100; "Manual Linking"; Boolean)
         {
             Caption = 'Manual Linking';
-            DataClassification = SystemMetadata;
         }
     }
 

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigFields.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigFields.Page.al
@@ -67,7 +67,7 @@ page 71033604 "SPB DBraider Config. Fields"
                 }
                 field("Write Enabled"; Rec."Write Enabled")
                 {
-                    Enabled = rec.Included;
+                    Enabled = Rec.Included;
                     ToolTip = 'Specifies the value of the Write Enabled field.';
                     Visible = WriteEndpoint;
                 }

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Page.al
@@ -167,7 +167,7 @@ page 71033603 "SPB DBraider Config. Line"
                         IndentErr: Label 'You can not indent a single table.';
                     begin
                         if Rec.CheckIndentation() then begin
-                            Rec.LockTable();
+                            Rec.ReadIsolation(IsolationLevel::UpdLock);
                             Rec.Indentation += 1;
                             Rec.UpdateParent();
                             Rec.CheckRelationshipConfigured();

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
@@ -144,21 +144,21 @@ table 71033602 "SPB DBraider Config. Line"
         if Rec."Line No." <> 0 then begin
             DBraiderConfLineFieldSBI.SetRange("Config. Code", Rec."Config. Code");
             DBraiderConfLineFieldSBI.SetRange("Config. Line No.", Rec."Line No.");
-            if DBraiderConfLineFieldSBI.IsEmpty then begin
+            if DBraiderConfLineFieldSBI.IsEmpty() then begin
                 // Populate the dataset
                 RecRef.Open("Source Table");
                 PKFieldNumbers := SPBDBraiderUtilities.GetPrimaryKeyFields(RecRef);
-                for i := 1 to RecRef.FieldCount do begin
+                for i := 1 to RecRef.FieldCount() do begin
                     FieldsRef := RecRef.FieldIndex(i);
                     DBraiderConfLineFieldSBI.Init();
                     DBraiderConfLineFieldSBI."Config. Code" := Rec."Config. Code";
                     DBraiderConfLineFieldSBI."Config. Line No." := Rec."Line No.";
-                    DBraiderConfLineFieldSBI."Field No." := FieldsRef.Number;
+                    DBraiderConfLineFieldSBI."Field No." := FieldsRef.Number();
                     DBraiderConfLineFieldSBI."Table No." := Rec."Source Table";
                     DBraiderConfLineFieldSBI."Processing Order" := 10;
-                    DBraiderConfLineFieldSBI."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type);
-                    DBraiderConfLineFieldSBI."Field Class" := Format(FieldsRef.Class);
-                    DBraiderConfLineFieldSBI."Primary Key" := PKFieldNumbers.Contains(FieldsRef.Number);
+                    DBraiderConfLineFieldSBI."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type());
+                    DBraiderConfLineFieldSBI."Field Class" := Format(FieldsRef.Class());
+                    DBraiderConfLineFieldSBI."Primary Key" := PKFieldNumbers.Contains(FieldsRef.Number());
                     DBraiderConfLineFieldSBI.Insert(true);
                     // Because flowfields aren't searchable, we need to copy the caption to a Normal class field
                     DBraiderConfLineFieldSBI.CalcFields("Field Name", Caption);
@@ -211,7 +211,7 @@ table 71033602 "SPB DBraider Config. Line"
     begin
         DBRelation.SetRange("Config. Code", Rec."Config. Code");
         DBRelation.SetRange("Config. Line No.", Rec."Line No.");
-        if not DBRelation.IsEmpty then begin
+        if not DBRelation.IsEmpty() then begin
             if DBRelation.FindSet(false) then
                 repeat
                     MissingInfo := (DBRelation."Parent Field No." = 0) or (DBRelation."Child Field No." = 0);

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
@@ -8,19 +8,16 @@ table 71033602 "SPB DBraider Config. Line"
         field(1; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header".Code;
         }
         field(2; "Line No."; Integer)
         {
             Caption = 'Line No.';
-            DataClassification = SystemMetadata;
         }
 
         field(10; "Source Table"; Integer)
         {
             Caption = 'Source Table';
-            DataClassification = SystemMetadata;
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Table));
 
             trigger OnValidate()
@@ -45,31 +42,26 @@ table 71033602 "SPB DBraider Config. Line"
         field(20; Indentation; Integer)
         {
             Caption = 'Indentation';
-            DataClassification = SystemMetadata;
         }
         field(21; "Parent Table No."; Integer)
         {
             Caption = 'Parent Table No.';
-            DataClassification = SystemMetadata;
             Editable = false;
         }
 
         field(50; "Relation Type"; Enum "SPB DBraider Relation Type")
         {
             Caption = 'Relation Type';
-            DataClassification = SystemMetadata;
         }
 
         field(55; "Relation Operation"; Enum "SPB DBraider Rel. Operation")
         {
             Caption = 'Relation Operation';
-            DataClassification = SystemMetadata;
         }
 
         field(59; "Relationship Configured"; Boolean)
         {
             Caption = 'Relationship Configured';
-            DataClassification = SystemMetadata;
             Editable = false;
         }
 

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfigLine.Table.al
@@ -37,6 +37,7 @@ table 71033602 "SPB DBraider Config. Line"
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Source Table")));
             Caption = 'Source Table Name';
             FieldClass = FlowField;
+            Editable = false;
         }
 
         field(20; Indentation; Integer)

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLog.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLog.Page.al
@@ -68,7 +68,7 @@ page 71033612 "SPB DBraider End. Log"
     {
         area(Promoted)
         {
-            actionref(RetryApiInput_Promoted; RetryAPIInput) { }
+            actionref(RetryApiInput_Promoted; RetryApiInput) { }
         }
         area(Processing)
         {
@@ -112,7 +112,7 @@ page 71033612 "SPB DBraider End. Log"
         Rec.CalcFields("Raw Input", "Raw Output");
 
         // Read the contents of the "Raw Input" and "Raw Output" BLOB fields into texts
-        if rec."Raw Input".HasValue then begin
+        if Rec."Raw Input".HasValue then begin
             Rec."Raw Input".CreateInStream(inS);
             while not inS.EOS do begin
                 inS.ReadText(LineOfText);
@@ -125,7 +125,7 @@ page 71033612 "SPB DBraider End. Log"
         BlobTextBuilder.Clear();
         Clear(inS);
         Clear(LineOfText);
-        if rec."Raw Output".HasValue then begin
+        if Rec."Raw Output".HasValue then begin
             Rec."Raw Output".CreateInStream(inS);
             while not inS.EOS do begin
                 inS.ReadText(LineOfText);

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLog.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLog.Page.al
@@ -112,9 +112,9 @@ page 71033612 "SPB DBraider End. Log"
         Rec.CalcFields("Raw Input", "Raw Output");
 
         // Read the contents of the "Raw Input" and "Raw Output" BLOB fields into texts
-        if Rec."Raw Input".HasValue then begin
+        if Rec."Raw Input".HasValue() then begin
             Rec."Raw Input".CreateInStream(inS);
-            while not inS.EOS do begin
+            while not inS.EOS() do begin
                 inS.ReadText(LineOfText);
                 BlobTextBuilder.AppendLine(LineOfText);
             end;
@@ -125,9 +125,9 @@ page 71033612 "SPB DBraider End. Log"
         BlobTextBuilder.Clear();
         Clear(inS);
         Clear(LineOfText);
-        if Rec."Raw Output".HasValue then begin
+        if Rec."Raw Output".HasValue() then begin
             Rec."Raw Output".CreateInStream(inS);
-            while not inS.EOS do begin
+            while not inS.EOS() do begin
                 inS.ReadText(LineOfText);
                 BlobTextBuilder.AppendLine(LineOfText);
             end;

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLogs.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndLogs.Page.al
@@ -42,7 +42,7 @@ page 71033610 "SPB DBraider End. Logs"
     {
         area(Promoted)
         {
-            actionref(RetryApiInput_Promoted; RetryAPIInput) { }
+            actionref(RetryApiInput_Promoted; RetryApiInput) { }
         }
 
         area(Processing)

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
@@ -48,7 +48,7 @@ table 71033609 "SPB DBraider Endpoint Log"
         BlobTextBuilder: TextBuilder;
         RequestJsonString: Text;
         RequestDataErr: Label 'This Entry has invalid request data.';
-
+        DeltaReadNotSupportedErr: Label 'Delta Read is not supported in this context';
     begin
         Rec.CalcFields("Raw Input");
         if Rec."Raw Input".HasValue() then begin
@@ -65,7 +65,7 @@ table 71033609 "SPB DBraider Endpoint Log"
                 "SPB DBraider Endpoint Type"::Batch, "SPB DBraider Endpoint Type"::"Per Record":
                     SBPDBraiderInputProcessor.ProcessWriteData(DBHeader.Code, RequestJsonString);
                 "SPB DBraider Endpoint Type"::"Delta Read":
-                    Error('Delta Read is not supported in this context');
+                    Error(DeltaReadNotSupportedErr);
                 "SPB DBraider Endpoint Type"::"Read Only":
                     begin
                         if RequestJsonString <> '' then

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
@@ -51,7 +51,7 @@ table 71033609 "SPB DBraider Endpoint Log"
 
     begin
         Rec.CalcFields("Raw Input");
-        if rec."Raw Input".HasValue then begin
+        if Rec."Raw Input".HasValue then begin
             Rec."Raw Input".CreateInStream(inS);
             while not inS.EOS do begin
                 inS.ReadText(LineOfText);

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderEndpointLog.Table.al
@@ -51,9 +51,9 @@ table 71033609 "SPB DBraider Endpoint Log"
 
     begin
         Rec.CalcFields("Raw Input");
-        if Rec."Raw Input".HasValue then begin
+        if Rec."Raw Input".HasValue() then begin
             Rec."Raw Input".CreateInStream(inS);
-            while not inS.EOS do begin
+            while not inS.EOS() do begin
                 inS.ReadText(LineOfText);
                 BlobTextBuilder.AppendLine(LineOfText);
             end;

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderLogging.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderLogging.Codeunit.al
@@ -37,7 +37,7 @@ codeunit 71033614 "SPB DBraider Logging"
         if not DBHeader."Logging Enabled" then
             exit;
 
-        if format(DBHeader."Clear Older Than") <> '' then begin
+        if Format(DBHeader."Clear Older Than") <> '' then begin
             OlderThenDate := CalcDate(DBHeader."Clear Older Than", Today());
             if OlderThenDate < Today() then begin //we can't delete future entries
                 SPBDBraiderEndpointLog.SetRange("Config. Code", DBHeader.Code);
@@ -53,7 +53,7 @@ codeunit 71033614 "SPB DBraider Logging"
             if SPBDBraiderEndpointLog.Count > DBHeader."Clear Logs Count" then
                 repeat
                     if SPBDBraiderEndpointLog.FindSet() then begin
-                        SPBDBraiderEndpointLog.SetFilter("Entry No.", format(SPBDBraiderEndpointLog."Entry No."));
+                        SPBDBraiderEndpointLog.SetFilter("Entry No.", Format(SPBDBraiderEndpointLog."Entry No."));
                         SPBDBraiderEndpointLog.Delete(true);
                     end;
                     Clear(SPBDBraiderEndpointLog);

--- a/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderLogging.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Logging/SPBDBraiderLogging.Codeunit.al
@@ -50,7 +50,7 @@ codeunit 71033614 "SPB DBraider Logging"
         if DBHeader."Clear Logs Count" > 0 then begin  //can not delete negitive entries
             Clear(SPBDBraiderEndpointLog);
             SPBDBraiderEndpointLog.SetRange("Config. Code", DBHeader.Code);
-            if SPBDBraiderEndpointLog.Count > DBHeader."Clear Logs Count" then
+            if SPBDBraiderEndpointLog.Count() > DBHeader."Clear Logs Count" then
                 repeat
                     if SPBDBraiderEndpointLog.FindSet() then begin
                         SPBDBraiderEndpointLog.SetFilter("Entry No.", Format(SPBDBraiderEndpointLog."Entry No."));
@@ -58,7 +58,7 @@ codeunit 71033614 "SPB DBraider Logging"
                     end;
                     Clear(SPBDBraiderEndpointLog);
                     SPBDBraiderEndpointLog.SetRange("Config. Code", DBHeader.Code);
-                until SPBDBraiderEndpointLog.Count = DBHeader."Clear Logs Count";
+                until SPBDBraiderEndpointLog.Count() = DBHeader."Clear Logs Count";
         end;
     end;
 

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
@@ -286,7 +286,7 @@ table 71033601 "SPB DBraider Config. Header"
         ConfigLines: Record "SPB DBraider Config. Line";
     begin
         ConfigLines.SetRange("Config. Code", Rec.Code);
-        exit(not ConfigLines.IsEmpty);
+        exit(not ConfigLines.IsEmpty());
     end;
 
     internal procedure WriteableConfig(): Boolean

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
@@ -9,6 +9,7 @@ table 71033601 "SPB DBraider Config. Header"
         field(1; "Code"; Code[20])
         {
             Caption = 'Code';
+            NotBlank = true;
         }
         field(10; Description; Text[100])
         {

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigHeader.Table.al
@@ -9,22 +9,18 @@ table 71033601 "SPB DBraider Config. Header"
         field(1; "Code"; Code[20])
         {
             Caption = 'Code';
-            DataClassification = SystemMetadata;
         }
         field(10; Description; Text[100])
         {
             Caption = 'Description';
-            DataClassification = SystemMetadata;
         }
         field(20; "Last Run Duration"; Duration)
         {
             Caption = 'Last Run Duration';
-            DataClassification = SystemMetadata;
         }
         field(30; "Endpoint Type"; Enum "SPB DBraider Endpoint Type")
         {
             Caption = 'Endpoint Type';
-            DataClassification = SystemMetadata;
             ValuesAllowed = "Read Only", "Per Record", Batch;
 
             trigger OnValidate()
@@ -66,71 +62,60 @@ table 71033601 "SPB DBraider Config. Header"
         field(35; Enabled; Boolean)
         {
             Caption = 'Enabled';
-            DataClassification = SystemMetadata;
             InitValue = true;
         }
 
         field(40; "Require PK"; Boolean)
         {
             Caption = 'Require Entire Primary Key';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
 
         field(50; "Insert Allowed"; Boolean)
         {
             Caption = 'Insert Allowed';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(51; "Modify Allowed"; Boolean)
         {
             Caption = 'Modify Allowed';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(52; "Delete Allowed"; Boolean)
         {
             Caption = 'Delete Allowed';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(53; "Prevent Reading"; Boolean)
         {
             Caption = 'Prevent Reading';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
 
         field(60; "Disable Auto ModifiedAt"; Boolean)
         {
             Caption = 'Disable Auto ModifiedAt';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(61; "Disable Auto SystemId"; Boolean)
         {
             Caption = 'Disable Auto SystemId';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(62; "Hide from Lists"; Boolean)
         {
             Caption = 'Hide from Lists';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
         field(80; "Disable Related Id"; Boolean)
         {
             Caption = 'Disable Related Id';
-            DataClassification = SystemMetadata;
             InitValue = false;
         }
 
         field(100; "Output JSON Type"; Enum "SPB DBraider Output Json Type")
         {
             Caption = 'Output JSON Type';
-            DataClassification = SystemMetadata;
 
             trigger OnValidate()
             begin
@@ -141,12 +126,10 @@ table 71033601 "SPB DBraider Config. Header"
         field(200; "Logging Enabled"; Boolean)
         {
             Caption = 'Logging Enabled';
-            DataClassification = SystemMetadata;
         }
         field(201; "Clear Logs Count"; Integer)
         {
             Caption = 'Clear Logs Count';
-            DataClassification = SystemMetadata;
             InitValue = 100;
             MaxValue = 10000;
             MinValue = 0;
@@ -154,13 +137,11 @@ table 71033601 "SPB DBraider Config. Header"
         field(202; "Clear Older Than"; DateFormula)
         {
             Caption = 'Clear Older Than';
-            DataClassification = SystemMetadata;
         }
         field(210; "Page Size"; Integer)
         {
             BlankZero = true;
             Caption = 'Page Size';
-            DataClassification = SystemMetadata;
             MaxValue = 200000;
             MinValue = 0;
         }
@@ -168,27 +149,22 @@ table 71033601 "SPB DBraider Config. Header"
         field(220; "Emit Telemetry Read Before"; Boolean)
         {
             Caption = 'Emit Telemetry - Read OnBefore';
-            DataClassification = SystemMetadata;
         }
         field(221; "Emit Telemetry Read After"; Boolean)
         {
             Caption = 'Emit Telemetry - Read OnAfter';
-            DataClassification = SystemMetadata;
         }
         field(222; "Emit Telemetry Write Before"; Boolean)
         {
             Caption = 'Emit Telemetry - Write OnBefore';
-            DataClassification = SystemMetadata;
         }
         field(223; "Emit Telemetry Write After"; Boolean)
         {
             Caption = 'Emit Telemetry - Write OnAfter';
-            DataClassification = SystemMetadata;
         }
         field(225; "Emit Telemetry Include Body"; Boolean)
         {
             Caption = 'Emit Telemetry - Include Body';
-            DataClassification = SystemMetadata;
 
             trigger OnValidate()
             var
@@ -202,7 +178,6 @@ table 71033601 "SPB DBraider Config. Header"
         field(250; "Data Archive Versions"; Integer)
         {
             Caption = 'Data Archive Versions';
-            DataClassification = SystemMetadata;
             InitValue = 1;
             MaxValue = 10;
             MinValue = 0;

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfiguration.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfiguration.Page.al
@@ -238,7 +238,7 @@ page 71033602 "SPB DBraider Configuration"
                 var
                     MissingEndpointNameErrorLbl: Label 'You need to enter an Endpoint Name before you can copy lines from another Endpoint, the ''Code'' field can not be blank.';
                 begin
-                    if rec.Code = '' then //Added to preventing creating an endpoint with no name(Code).
+                    if Rec.Code = '' then //Added to preventing creating an endpoint with no name(Code).
                         Error(MissingEndpointNameErrorLbl)
                     else
                         CopyLinesFromOtherConfig();

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigurations.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigurations.Page.al
@@ -208,7 +208,7 @@ page 71033601 "SPB DBraider Configurations"
                     Caption = 'Support Wizard';
                     Image = ViewServiceOrder;
                     ToolTip = 'Open the Data Braider Support Wizard';
-                    RunObject = Page "SPB Braider Support Wizard";
+                    RunObject = page "SPB Braider Support Wizard";
                 }
             }
         }

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderCopyConfigFrom.Report.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderCopyConfigFrom.Report.al
@@ -16,10 +16,11 @@ report 71033600 "SPB DBraider Copy Config From"
         ConfigFlowsTo: Record "SPB DBraider ConfLine Flow";
         ConfigRelFrom: Record "SPB DBraider ConfLine Relation";
         ConfigRelTo: Record "SPB DBraider ConfLine Relation";
+        ConfirmManagement: Codeunit "Confirm Management";
         ConfigLinesList: Page "SPB DBraider Configurations";
         FilterOnConfHeaderCodeLbl: Label '<>%1', Comment = '%1 = DBraider Config Header Code';
     begin
-        if SPBDBraiderConfigHeaderDestination.HasExistingLines() and not Confirm('You have existing lines on this Configuration, which will be deleted and replaced. Continue?', true) then
+        if SPBDBraiderConfigHeaderDestination.HasExistingLines() and not ConfirmManagement.GetResponseOrDefault('You have existing lines on this Configuration, which will be deleted and replaced. Continue?', true) then
             exit
         else begin
             ConfigLinesTo.SetRange("Config. Code", SPBDBraiderConfigHeaderDestination.Code);

--- a/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
+++ b/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
@@ -117,7 +117,7 @@ page 71033617 "SPB Create Endpoints"
 
     trigger OnOpenPage()
     begin
-        foreach EndpointEnumSelectionText in EndpointEnumSelection.Names do begin
+        foreach EndpointEnumSelectionText in EndpointEnumSelection.Names() do begin
             Rec.Init();
             Rec.Code := Format(EndpointEnumSelectionText);
             Rec.Description := StrSubstNo(BaseEndpointNameTxt, CopyStr(Format(EndpointEnumSelectionText), 4));

--- a/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
+++ b/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
@@ -15,13 +15,13 @@ page 71033617 "SPB Create Endpoints"
         {
             repeater(EndpointSelections)
             {
-                field("Code"; rec.Code)
+                field("Code"; Rec.Code)
                 {
                     ApplicationArea = All;
                     ToolTip = 'Endpoint Call Code';
-                    editable = false;
+                    Editable = false;
                 }
-                field(Enabled; rec.Enabled)
+                field(Enabled; Rec.Enabled)
                 {
                     Caption = 'Create Data Braider Endpoints';
                     ApplicationArea = All;
@@ -29,7 +29,7 @@ page 71033617 "SPB Create Endpoints"
                     Editable = true;
                 }
 
-                field(Overwrite; rec."Logging Enabled") //Used on this page as "Overwrite"
+                field(Overwrite; Rec."Logging Enabled") //Used on this page as "Overwrite"
                 {
                     Caption = 'Overwrite';
                     ApplicationArea = All;
@@ -60,7 +60,7 @@ page 71033617 "SPB Create Endpoints"
                 Image = CancelFALedgerEntries;
                 trigger OnAction()
                 begin
-                    rec.ModifyAll(Enabled, false);
+                    Rec.ModifyAll(Enabled, false);
                 end;
             }
             action(SelectAllEndpoindSelection)
@@ -71,7 +71,7 @@ page 71033617 "SPB Create Endpoints"
                 Image = CancelFALedgerEntries;
                 trigger OnAction()
                 begin
-                    rec.ModifyAll(Enabled, true);
+                    Rec.ModifyAll(Enabled, true);
                 end;
             }
             action(SelectAllOverwrite)
@@ -83,9 +83,9 @@ page 71033617 "SPB Create Endpoints"
                 trigger OnAction()
 
                 begin
-                    rec.SetRange(Enabled, true);
-                    rec.ModifyAll(rec."Logging Enabled", true);
-                    rec.SetRange(Enabled);
+                    Rec.SetRange(Enabled, true);
+                    Rec.ModifyAll(Rec."Logging Enabled", true);
+                    Rec.SetRange(Enabled);
                 end;
             }
             action(AddSelectedEndpoints)
@@ -118,12 +118,11 @@ page 71033617 "SPB Create Endpoints"
     trigger OnOpenPage()
     begin
         foreach EndpointEnumSelectionText in EndpointEnumSelection.Names do begin
-            rec.Init();
-            rec.Code := format(EndpointEnumSelectionText);
-            rec.Description := StrSubstNo(BaseEndpointNameTxt, CopyStr(format(EndpointEnumSelectionText), 4));
-            rec.Enabled := false;
-            rec.Insert();
+            Rec.Init();
+            Rec.Code := Format(EndpointEnumSelectionText);
+            Rec.Description := StrSubstNo(BaseEndpointNameTxt, CopyStr(Format(EndpointEnumSelectionText), 4));
+            Rec.Enabled := false;
+            Rec.Insert();
         end;
     end;
-
 }

--- a/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
+++ b/SBIDataBraider_APP/src/Endpoint Automation/SPBCreateEndpoints.Page.al
@@ -17,14 +17,12 @@ page 71033617 "SPB Create Endpoints"
             {
                 field("Code"; Rec.Code)
                 {
-                    ApplicationArea = All;
                     ToolTip = 'Endpoint Call Code';
                     Editable = false;
                 }
                 field(Enabled; Rec.Enabled)
                 {
                     Caption = 'Create Data Braider Endpoints';
-                    ApplicationArea = All;
                     ToolTip = 'Endpoint Enabled or not';
                     Editable = true;
                 }

--- a/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetCol.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetCol.Table.al
@@ -8,49 +8,40 @@ table 71033606 "SPB DBraider Resultset Col"
         field(1; "Row No."; Integer)
         {
             Caption = 'Row No.';
-            DataClassification = SystemMetadata;
         }
         field(2; "Column No."; Integer)
         {
             Caption = 'Column No.';
-            DataClassification = SystemMetadata;
         }
         field(10; "Data Type"; Enum "SPB DBraider Field Data Type")
         {
             Caption = 'Data Type';
-            DataClassification = SystemMetadata;
         }
         field(20; "Value as Text"; Text[250])
         {
             Caption = 'Value as Text';
-            DataClassification = SystemMetadata;
         }
         field(30; "Field Name"; Text[30])
         {
             Caption = 'Field Name';
-            DataClassification = SystemMetadata;
         }
         field(31; "Forced Field Caption"; Text[250])
         {
             Caption = 'Forced Field Caption';
-            DataClassification = SystemMetadata;
         }
 
         field(35; "Field No."; Integer)
         {
             Caption = 'Field No.';
-            DataClassification = SystemMetadata;
         }
         field(50; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header";
         }
         field(100; "Source Table"; Integer)
         {
             Caption = 'Source Table';
-            DataClassification = SystemMetadata;
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Table));
         }
         field(120; "Field Class"; Text[100])
@@ -60,63 +51,51 @@ table 71033606 "SPB DBraider Resultset Col"
         field(201; "Source SystemId"; Guid)
         {
             Caption = 'Source SystemId';
-            DataClassification = SystemMetadata;
         }
         field(202; "Top-Level SystemId"; Guid)
         {
             Caption = 'Top-Level SystemId';
-            DataClassification = SystemMetadata;
         }
         field(210; "Write Result Record"; Boolean)
         {
             Caption = 'Write Result Record';
-            DataClassification = SystemMetadata;
         }
 
         field(1000; TextCell; Text[250])
         {
             Caption = 'TextCell';
-            DataClassification = SystemMetadata;
         }
         field(2000; CodeCell; Code[250])
         {
             Caption = 'CodeCell';
-            DataClassification = SystemMetadata;
         }
         field(3000; NumberCell; Decimal)
         {
             Caption = 'NumberCell';
-            DataClassification = SystemMetadata;
         }
         field(4000; DateCell; Date)
         {
             Caption = 'DateCell';
-            DataClassification = SystemMetadata;
         }
         field(5000; TimeCell; Time)
         {
             Caption = 'TimeCell';
-            DataClassification = SystemMetadata;
         }
         field(6000; DatetimeCell; DateTime)
         {
             Caption = 'DatetimeCell';
-            DataClassification = SystemMetadata;
         }
         field(7000; BooleanCell; Boolean)
         {
             Caption = 'BooleanCell';
-            DataClassification = SystemMetadata;
         }
         field(8000; GuidCell; Guid)
         {
             Caption = 'GuidCell';
-            DataClassification = SystemMetadata;
         }
         field(25000; "FQ SystemId"; Text[400])
         {
             Caption = 'FQ SystemId';
-            DataClassification = SystemMetadata;
         }
     }
     keys

--- a/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetRow.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetRow.Table.al
@@ -8,39 +8,32 @@ table 71033605 "SPB DBraider Resultset Row"
         field(1; "Row No."; Integer)
         {
             Caption = 'Row No.';
-            DataClassification = SystemMetadata;
         }
         field(10; "Data Level"; Integer)
         {
             Caption = 'Data Level';
-            DataClassification = SystemMetadata;
         }
         field(20; Keyname; Text[50])
         {
             Caption = 'Keyname';
-            DataClassification = SystemMetadata;
         }
         field(30; "Header Row"; Boolean)
         {
             Caption = 'Header Row';
-            DataClassification = SystemMetadata;
         }
         field(40; "Belongs To Row No."; Integer)
         {
             Caption = 'Belongs To Row No.';
-            DataClassification = SystemMetadata;
         }
         field(50; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header";
         }
 
         field(100; "Source Table"; Integer)
         {
             Caption = 'Source Table';
-            DataClassification = SystemMetadata;
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Table));
         }
         field(110; "Source Table Name"; Text[30])
@@ -53,38 +46,31 @@ table 71033605 "SPB DBraider Resultset Row"
         field(200; "Primary Key String"; Text[250])
         {
             Caption = 'Primary Key String';
-            DataClassification = SystemMetadata;
         }
         field(201; "Source SystemId"; Guid)
         {
             Caption = 'Source SystemId';
-            DataClassification = SystemMetadata;
         }
         field(202; "Top-Level SystemId"; Guid)
         {
             Caption = 'Top-Level SystemId';
-            DataClassification = SystemMetadata;
         }
         field(210; "Buffer Type"; Enum "SPB DBraider Buffer Type")
         {
             Caption = 'Buffer Type';
-            DataClassification = SystemMetadata;
         }
         field(211; "Data Mode"; Option)
         {
             Caption = 'Data Mode';
-            DataClassification = SystemMetadata;
             OptionMembers = "Read","Write";
         }
         field(300; "Delta Type"; Enum "SPB DBraider Delta Type")
         {
             Caption = 'Delta Type';
-            DataClassification = SystemMetadata;
         }
         field(25000; "FQ SystemId"; Text[400])
         {
             Caption = 'FQ SystemId';
-            DataClassification = SystemMetadata;
         }
     }
     keys

--- a/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetRow.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/BufferTables/SPBDBraiderResultsetRow.Table.al
@@ -41,6 +41,7 @@ table 71033605 "SPB DBraider Resultset Row"
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Source Table")));
             Caption = 'Source Table Name';
             FieldClass = FlowField;
+            Editable = false;
         }
 
         field(200; "Primary Key String"; Text[250])

--- a/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONFlat.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONFlat.Codeunit.al
@@ -8,7 +8,7 @@ codeunit 71033612 "SPB DBraid DStoJSON Flat" implements "SPB DBraider IDatasetTo
         ResultTextLbl: Label 'No Result was found with the given filter(s)';
         ResultText: Text;
     begin
-        if BaseResultCol.IsEmpty or BaseResultRow.IsEmpty then begin
+        if BaseResultCol.IsEmpty() or BaseResultRow.IsEmpty() then begin
             ResultText := ResultTextLbl;
             exit(ResultText);
         end;
@@ -77,7 +77,7 @@ codeunit 71033612 "SPB DBraid DStoJSON Flat" implements "SPB DBraider IDatasetTo
                 foreach FieldFullname in FieldList do
                     JsonCols.Add(FieldFullname, ''); */
 
-                if JsonPrefixes.Keys.Count <> 0 then
+                if JsonPrefixes.Keys().Count() <> 0 then
                     // This is a way to 'prepend' some values to the json, used by the WriteTemplate system
                     JsonCols := JsonPrefixes.Clone().AsObject();
 

--- a/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONFlat.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONFlat.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 71033612 "SPB DBraid DStoJSON Flat" implements "SPB DBraider IDatasetTo
         exit(JsonRows);
     end;
 
-    internal procedure ProcessDataFlatToJson(DBHeader: Record "SPB DBraider Config. Header") JsonRows: JsonArray;
+    internal procedure ProcessDataFlatToJson(DBHeader: Record "SPB DBraider Config. Header") JsonRows: JsonArray
     var
         UseWriteResponseFiltering: Boolean;
         MaximumDepth: Integer;

--- a/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONHierarchy.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONHierarchy.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 71033611 "SPB DBraid DStoJSON Hierarchy" implements "SPB DBraider IData
         exit(JsonRows);
     end;
 
-    internal procedure ProcessDataHierarchyToJson() JsonRows: JsonArray;
+    internal procedure ProcessDataHierarchyToJson() JsonRows: JsonArray
     var
         IntValue: Integer;
         JsonCols: JsonObject;

--- a/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONHierarchy.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DatasetToOutputs/SPBDBraidDStoJSONHierarchy.Codeunit.al
@@ -8,7 +8,7 @@ codeunit 71033611 "SPB DBraid DStoJSON Hierarchy" implements "SPB DBraider IData
         ResultTextLbl: Label 'No Result was found with the given filter(s)';
         ResultText: Text;
     begin
-        if BaseResultCol.IsEmpty or BaseResultRow.IsEmpty then begin
+        if BaseResultCol.IsEmpty() or BaseResultRow.IsEmpty() then begin
             ResultText := ResultTextLbl;
             exit(ResultText);
         end;

--- a/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderBuildDelta.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderBuildDelta.Codeunit.al
@@ -186,7 +186,7 @@ codeunit 71033616 "SPB DBraider Build Delta"
                 TempResultRow2.SetFilter("Data Level", '<>%1', 10000);  //top level
                 TempResultRow2.SetRange("Top-Level SystemId", TempNewResultRow."Source SystemId");
                 TempResultRow2.SetFilter("Delta Type", '<>%1', TempResultRow2."Delta Type"::" ");
-                if not TempResultRow2.IsEmpty then begin
+                if not TempResultRow2.IsEmpty() then begin
                     TempNewResultRow."Delta Type" := TempNewResultRow."Delta Type"::ChildUpdates;
                     TempNewResultRow.Modify();
                 end;

--- a/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaCol.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaCol.Table.al
@@ -8,38 +8,31 @@ table 71033612 "SPB DBraider Delta Col"
         field(1; "Row No."; Integer)
         {
             Caption = 'Row No.';
-            DataClassification = SystemMetadata;
         }
         field(2; "Column No."; Integer)
         {
             Caption = 'Column No.';
-            DataClassification = SystemMetadata;
         }
         field(10; "Data Type"; Enum "SPB DBraider Field Data Type")
         {
             Caption = 'Data Type';
-            DataClassification = SystemMetadata;
         }
         field(20; "Value as Text"; Text[250])
         {
             Caption = 'Value as Text';
-            DataClassification = SystemMetadata;
         }
         field(30; "Field Name"; Text[30])
         {
             Caption = 'Field Name';
-            DataClassification = SystemMetadata;
         }
 
         field(35; "Field No."; Integer)
         {
             Caption = 'Field No.';
-            DataClassification = SystemMetadata;
         }
         field(50; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header";
         }
         field(51; "Version No."; Integer)
@@ -49,7 +42,6 @@ table 71033612 "SPB DBraider Delta Col"
         field(100; "Source Table"; Integer)
         {
             Caption = 'Source Table';
-            DataClassification = SystemMetadata;
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Table));
         }
         field(120; "Field Class"; Text[100])
@@ -59,58 +51,47 @@ table 71033612 "SPB DBraider Delta Col"
         field(201; "Source SystemId"; Guid)
         {
             Caption = 'Source SystemId';
-            DataClassification = SystemMetadata;
         }
         field(202; "Top-Level SystemId"; Guid)
         {
             Caption = 'Top-Level SystemId';
-            DataClassification = SystemMetadata;
         }
 
         field(1000; TextCell; Text[250])
         {
             Caption = 'TextCell';
-            DataClassification = SystemMetadata;
         }
         field(2000; CodeCell; Code[250])
         {
             Caption = 'CodeCell';
-            DataClassification = SystemMetadata;
         }
         field(3000; NumberCell; Decimal)
         {
             Caption = 'NumberCell';
-            DataClassification = SystemMetadata;
         }
         field(4000; DateCell; Date)
         {
             Caption = 'DateCell';
-            DataClassification = SystemMetadata;
         }
         field(5000; TimeCell; Time)
         {
             Caption = 'TimeCell';
-            DataClassification = SystemMetadata;
         }
         field(6000; DatetimeCell; DateTime)
         {
             Caption = 'DatetimeCell';
-            DataClassification = SystemMetadata;
         }
         field(7000; BooleanCell; Boolean)
         {
             Caption = 'BooleanCell';
-            DataClassification = SystemMetadata;
         }
         field(8000; GuidCell; Guid)
         {
             Caption = 'GuidCell';
-            DataClassification = SystemMetadata;
         }
         field(25000; "FQ SystemId"; Text[400])
         {
             Caption = 'FQ SystemId';
-            DataClassification = SystemMetadata;
         }
     }
     keys

--- a/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaRow.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaRow.Table.al
@@ -45,6 +45,7 @@ table 71033611 "SPB DBraider Delta Row"
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Source Table")));
             Caption = 'Source Table Name';
             FieldClass = FlowField;
+            Editable = false;
         }
 
         field(200; "Primary Key String"; Text[250])

--- a/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaRow.Table.al
+++ b/SBIDataBraider_APP/src/EngineOperations/DeltaRead/SPBDBraiderDeltaRow.Table.al
@@ -8,32 +8,26 @@ table 71033611 "SPB DBraider Delta Row"
         field(1; "Row No."; Integer)
         {
             Caption = 'Row No.';
-            DataClassification = SystemMetadata;
         }
         field(10; "Data Level"; Integer)
         {
             Caption = 'Data Level';
-            DataClassification = SystemMetadata;
         }
         field(20; Keyname; Text[50])
         {
             Caption = 'Keyname';
-            DataClassification = SystemMetadata;
         }
         field(30; "Header Row"; Boolean)
         {
             Caption = 'Header Row';
-            DataClassification = SystemMetadata;
         }
         field(40; "Belongs To Row No."; Integer)
         {
             Caption = 'Belongs To Row No.';
-            DataClassification = SystemMetadata;
         }
         field(50; "Config. Code"; Code[20])
         {
             Caption = 'Config. Code';
-            DataClassification = SystemMetadata;
             TableRelation = "SPB DBraider Config. Header";
         }
         field(51; "Version No."; Integer)
@@ -44,7 +38,6 @@ table 71033611 "SPB DBraider Delta Row"
         field(100; "Source Table"; Integer)
         {
             Caption = 'Source Table';
-            DataClassification = SystemMetadata;
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Table));
         }
         field(110; "Source Table Name"; Text[30])
@@ -57,27 +50,22 @@ table 71033611 "SPB DBraider Delta Row"
         field(200; "Primary Key String"; Text[250])
         {
             Caption = 'Primary Key String';
-            DataClassification = SystemMetadata;
         }
         field(201; "Source SystemId"; Guid)
         {
             Caption = 'Source SystemId';
-            DataClassification = SystemMetadata;
         }
         field(202; "Top-Level SystemId"; Guid)
         {
             Caption = 'Top-Level SystemId';
-            DataClassification = SystemMetadata;
         }
         field(300; "Delta Type"; Enum "SPB DBraider Delta Type")
         {
             Caption = 'Delta Type';
-            DataClassification = SystemMetadata;
         }
         field(25000; "FQ SystemId"; Text[400])
         {
             Caption = 'FQ SystemId';
-            DataClassification = SystemMetadata;
         }
     }
     keys

--- a/SBIDataBraider_APP/src/EngineOperations/ErrorEngine/SPBDBraiderErrorSystem.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/ErrorEngine/SPBDBraiderErrorSystem.Codeunit.al
@@ -97,7 +97,7 @@ codeunit 71033613 "SPB DBraider Error System"
             ResultArray.Add(ThisJsonToken.Clone());
     end;
 
-    procedure GetBufferedErrors(): Record "SPB DBraider Result Buffer" temporary;
+    procedure GetBufferedErrors(): Record "SPB DBraider Result Buffer" temporary
     begin
         TempSPBDBraiderResultBuffer.SetRange("Result Type", Enum::"SPB DBraider Result Type"::Error);
         exit(TempSPBDBraiderResultBuffer);

--- a/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderInputProcessor.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderInputProcessor.Codeunit.al
@@ -55,7 +55,7 @@ codeunit 71033607 "SPB DBraider Input Processor"
 
     local procedure TryToBatchWriteData(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header";
     var TempJSONBuffer: Record "JSON Buffer" temporary;
-    var JsonResultArray: JsonArray) CompleteSuccess: Boolean;
+    var JsonResultArray: JsonArray) CompleteSuccess: Boolean
     var
         SPBDBraiderWriteData: Codeunit "SPB DBraider Write Data";
         WriteFailLbl: Label 'Writing data failed: %1', Comment = '%1 = Last Error Message';
@@ -75,7 +75,7 @@ codeunit 71033607 "SPB DBraider Input Processor"
 
     local procedure TryToSingleWriteData(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header";
     var TempJSONBuffer: Record "JSON Buffer" temporary;
-    var JsonResultArray: JsonArray) CompleteSuccess: Boolean;
+    var JsonResultArray: JsonArray) CompleteSuccess: Boolean
     var
         TempContentJsonBuffer: Record "JSON Buffer" temporary;
         TempHeaderJsonBuffer: Record "JSON Buffer" temporary;

--- a/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderInputValidator.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderInputValidator.Codeunit.al
@@ -195,7 +195,7 @@ codeunit 71033605 "SPB DBraider Input Validator"
             repeat
                 // Build a List of the Field Numbers that are mandatory for this config line
                 MandatoryFields := SPBDBraiderUtilities.GetMandatoryFieldsForConfig(TempStartRecordJsonBuffer."SPB Config. Code", TempStartRecordJsonBuffer."SPB Config. Line No.");
-                if MandatoryFields.Count <> 0 then begin
+                if MandatoryFields.Count() <> 0 then begin
                     // The TempMapJsonBuffer is a way to see what the Table/Field Names are, so prep the filters
                     TempMapJsonBuffer.SetRange("SPB Record Id", TempStartRecordJsonBuffer."SPB Record Id");
                     TempMapJsonBuffer.SetRange("SPB Config. Code", TempStartRecordJsonBuffer."SPB Config. Code");
@@ -241,15 +241,15 @@ codeunit 71033605 "SPB DBraider Input Validator"
         TargetKeyRef: KeyRef;
     begin
         // Initialize a Temporary (and blank) rec from the same table to get the InitValue for comparison
-        TempSampleRecordRef.Open(TargetTableRecordRef.Number, true);
+        TempSampleRecordRef.Open(TargetTableRecordRef.Number(), true);
 
         AllFieldsOK := true;
 
         TargetKeyRef := TargetTableRecordRef.KeyIndex(1);  // Primary Key
-        for i := 1 to TargetKeyRef.FieldCount do begin
+        for i := 1 to TargetKeyRef.FieldCount() do begin
             TargetFieldRef := TargetKeyRef.FieldIndex(i);
             SampleFieldRef := TempSampleRecordRef.FieldIndex(i);
-            AllFieldsOK := AllFieldsOK and (Format(TargetFieldRef.Value) <> Format(SampleFieldRef.Value));
+            AllFieldsOK := AllFieldsOK and (Format(TargetFieldRef.Value()) <> Format(SampleFieldRef.Value()));
         end;
     end;
 

--- a/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderJSONTemplMaker.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderJSONTemplMaker.Codeunit.al
@@ -2,7 +2,7 @@ codeunit 71033615 "SPB DBraider JSON Templ. Maker"
 {
     TableNo = "SPB DBraider Config. Line";
 
-    procedure GenerateTableToTemplate(var Rec: Record "SPB DBraider Config. Header"; MandatoryOnly: Boolean; TemplateActionType: Enum "SPB DBraider Change Action") JsonTemplateResult: Text;
+    procedure GenerateTableToTemplate(var Rec: Record "SPB DBraider Config. Header"; MandatoryOnly: Boolean; TemplateActionType: Enum "SPB DBraider Change Action") JsonTemplateResult: Text
     var
         TempBaseResultCol: Record "SPB DBraider Resultset Col" temporary;
         TempBaseResultRow: Record "SPB DBraider Resultset Row" temporary;

--- a/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderWriteData.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/InputWrite/SPBDBraiderWriteData.Codeunit.al
@@ -86,14 +86,14 @@ codeunit 71033606 "SPB DBraider Write Data"
             exit(false);
         AllObjects.SetRange("Object Type", AllObjects."Object Type"::Table);
         AllObjects.SetRange("Object ID", TempContentJsonBuffer."SPB Table No.");
-        if AllObjects.IsEmpty then
+        if AllObjects.IsEmpty() then
             exit(false);
 
 
         TargetRecordRef.Open(TempContentJsonBuffer."SPB Table No.");
         PrimaryKeyFields := SPBDBraiderUtilities.GetPrimaryKeyFields(TargetRecordRef);
 
-        for i := 1 to PrimaryKeyFields.Count do begin
+        for i := 1 to PrimaryKeyFields.Count() do begin
             PrimaryKeyFields.Get(i, FieldNo);
             TempFieldsJsonBuffer.SetRange("SPB Field No.", FieldNo);
             if TempFieldsJsonBuffer.FindFirst() then begin
@@ -110,10 +110,10 @@ codeunit 71033606 "SPB DBraider Write Data"
         //TODO: This needs to lookup the fields by what's submitted, sure, BUT we may also be 'assuming' some part of the PK from the parent record.
         ApplyInferredParentData(TempContentJsonBuffer, TargetRecordRef, LocatedKeyFields, MissingKeyFields);
 
-        if MissingKeyFields.Count > 0 then
+        if MissingKeyFields.Count() > 0 then
             exit(false);
 
-        foreach FieldNo in LocatedKeyFields.Keys do begin
+        foreach FieldNo in LocatedKeyFields.Keys() do begin
             TargetFieldRef := TargetRecordRef.Field(FieldNo);
             TargetFieldRef.SetFilter(LocatedKeyFields.Get(FieldNo));
         end;
@@ -199,7 +199,7 @@ codeunit 71033606 "SPB DBraider Write Data"
         if FindRecordRefByContent(TempContentJsonBuffer, TargetRecordRef, PKString) then begin
             TargetRecordRef.Delete(true);
             AddDeletedRecordToResults(PKString);
-            EventNoteMgt.CreateEventNote('', TargetRecordRef.Number, TargetRecordRef.RecordId, 'delete', PKString);
+            EventNoteMgt.CreateEventNote('', TargetRecordRef.Number(), TargetRecordRef.RecordId(), 'delete', PKString);
             RecordsAffected += 1;
         end else begin
             SPBDBraiderErrorSystem.AddError(TempContentJsonBuffer.GetRangeMin("SPB Record Id"), StrSubstNo(UnableToDeleteRecLbl, PKString));
@@ -223,7 +223,7 @@ codeunit 71033606 "SPB DBraider Write Data"
         TempResultRow.DeleteAll();
         TempResultCol.DeleteAll();
 
-        SpecificRecordRef.Open(TargetRecordRef.Number);
+        SpecificRecordRef.Open(TargetRecordRef.Number());
         SpecificRecordRef.SetPosition(TargetRecordRef.GetPosition());
         SpecificRecordRef.SetRecFilter();
         if DBraiderConfig.Get(TempContentJsonBuffer."SPB Config. Code") then begin  // Intentional: You can only get one result set, so findfirst.  If they filter on a range, first only!
@@ -245,7 +245,7 @@ codeunit 71033606 "SPB DBraider Write Data"
             ResultJsonObject.Add('action', ActionName);
             ResultJsonObject.Add('data', JsonResult);
             JsonResultArray.Add(ResultJsonObject.Clone());
-            EventNoteMgt.CreateEventNote(DBraiderConfig.Code, TargetRecordRef.Number, TargetRecordRef.RecordId, ActionName, '');
+            EventNoteMgt.CreateEventNote(DBraiderConfig.Code, TargetRecordRef.Number(), TargetRecordRef.RecordId(), ActionName, '');
         end;
     end;
 
@@ -327,15 +327,14 @@ codeunit 71033606 "SPB DBraider Write Data"
                     // then apply the parent field value to the TargetRecordRef's child field.
                     if LastRecordPosition.ContainsKey(SPBDBraiderConfLineRelation."Parent Table") then begin
                         ParentRecordRef.Open(SPBDBraiderConfLineRelation."Parent Table");
-                        ParentRecordRef.SetPosition(LastRecordPosition.Get(ParentRecordRef.Number));
+                        ParentRecordRef.SetPosition(LastRecordPosition.Get(ParentRecordRef.Number()));
                         if ParentRecordRef.Find('=') then begin
                             ParentFieldRef := ParentRecordRef.Field(SPBDBraiderConfLineRelation."Parent Field No.");
                             ChildFieldRef := TargetRecordRef.Field(SPBDBraiderConfLineRelation."Child Field No.");
                             //TODO: Consider an Advanced Setting to control this behavior
                             if SPBDBraiderConfLineField."Disable Validation" = SPBDBraiderConfLineField."Disable Validation"::DisableAll then
-                                ChildFieldRef.Value := ParentFieldRef.Value
-                            else
-                                ChildFieldRef.Validate(ParentFieldRef.Value);
+                                ChildFieldRef.Value := ParentFieldRef.Value() else
+                                ChildFieldRef.Validate(ParentFieldRef.Value());
                         end;
                         ParentRecordRef.Close();
                     end;
@@ -367,10 +366,10 @@ codeunit 71033606 "SPB DBraider Write Data"
                         // then apply the parent field value to the TargetRecordRef's child field.
                         if LastRecordPosition.ContainsKey(SPBDBraiderConfLineRelation."Parent Table") then begin
                             ParentRecordRef.Open(SPBDBraiderConfLineRelation."Parent Table");
-                            ParentRecordRef.SetPosition(LastRecordPosition.Get(ParentRecordRef.Number));
+                            ParentRecordRef.SetPosition(LastRecordPosition.Get(ParentRecordRef.Number()));
                             if ParentRecordRef.Find('=') then begin
                                 ParentFieldRef := ParentRecordRef.Field(SPBDBraiderConfLineRelation."Parent Field No.");
-                                LocatedKeyFields.Add(FieldNo, ParentFieldRef.Value);
+                                LocatedKeyFields.Add(FieldNo, ParentFieldRef.Value());
                                 InferredFields.Add(FieldNo);
                             end;
                             ParentRecordRef.Close();
@@ -394,7 +393,7 @@ codeunit 71033606 "SPB DBraider Write Data"
         // If we're dealing with a Modify, and the field is unchanged, we may not want to re-validate it.
         if InternalActionType = InternalActionType::Update then
             if not SPBDBraiderConfLineField."Modification Re-Validate" then
-                if Format(DestinationRecordRef.Field(FieldNo).Value) = Format(NewValue) then
+                if Format(DestinationRecordRef.Field(FieldNo).Value()) = Format(NewValue) then
                     exit;
 
         if SPBDBraiderConfLineField."Disable Validation" = SPBDBraiderConfLineField."Disable Validation"::DisableAll then
@@ -417,27 +416,27 @@ codeunit 71033606 "SPB DBraider Write Data"
         PrimaryKeyFields: List of [Integer];
     begin
         PrimaryKeyFields := SPBDBraiderUtilities.GetPrimaryKeyFields(TargetRecordRef);
-        LastFieldNo := PrimaryKeyFields.Get(PrimaryKeyFields.Count);
+        LastFieldNo := PrimaryKeyFields.Get(PrimaryKeyFields.Count());
         DestRecordLastFieldRef := TargetRecordRef.Field(LastFieldNo);
-        if DestRecordLastFieldRef.Type = FieldType::Integer then
+        if DestRecordLastFieldRef.Type() = FieldType::Integer then
             // Disable check from the Field settings on the ConfLine Field table
             if SPBDBraiderConfLineField.Get(TempContentJsonBuffer."SPB Config. Code", TempContentJsonBuffer."SPB Config. Line No.", LastFieldNo) then
                 if SPBDBraiderConfLineField."Disable Auto-Split Key" then
                     exit;
 
-        if Evaluate(i, Format(DestRecordLastFieldRef.Value)) then
+        if Evaluate(i, Format(DestRecordLastFieldRef.Value())) then
             // if the last field is an integer with a value of zero:
             if i = 0 then begin
                 // Find the 'last' record in the table with the other PK values if possible
-                TargetRecordRef2.Open(TargetRecordRef.Number);
-                if PrimaryKeyFields.Count > 1 then
-                    for i := 1 to (PrimaryKeyFields.Count - 1) do begin
+                TargetRecordRef2.Open(TargetRecordRef.Number());
+                if PrimaryKeyFields.Count() > 1 then
+                    for i := 1 to (PrimaryKeyFields.Count() - 1) do begin
                         TargetFieldRef1 := TargetRecordRef.Field(PrimaryKeyFields.Get(i));
                         TargetFieldRef2 := TargetRecordRef2.Field(PrimaryKeyFields.Get(i));
-                        TargetFieldRef2.SetFilter(Format(TargetFieldRef1.Value));
+                        TargetFieldRef2.SetFilter(Format(TargetFieldRef1.Value()));
                     end;
                 if TargetRecordRef2.FindLast() then
-                    Evaluate(NextLineNo, Format(TargetRecordRef2.Field(LastFieldNo).Value))
+                    Evaluate(NextLineNo, Format(TargetRecordRef2.Field(LastFieldNo).Value()))
                 else
                     NextLineNo := 0;
                 NextLineNo += 10000;
@@ -462,7 +461,7 @@ codeunit 71033606 "SPB DBraider Write Data"
 
     internal procedure SetLastRecord(WhichRecordRef: RecordRef)
     begin
-        SetLastRecord(WhichRecordRef.Number, WhichRecordRef.GetPosition());
+        SetLastRecord(WhichRecordRef.Number(), WhichRecordRef.GetPosition());
     end;
 
     [IntegrationEvent(false, false)]

--- a/SBIDataBraider_APP/src/EngineOperations/SPBDBraiderDataEngine.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/SPBDBraiderDataEngine.Codeunit.al
@@ -324,7 +324,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
             if (StartFromPage > 1) and (PageSize <> 0) and (DBLine."Parent Table No." = 0) then
                 repeat
                     i += 1;
-                until (LineRef.next() < 0) or (i >= SkipUntilRecord);
+                until (LineRef.Next() < 0) or (i >= SkipUntilRecord);
             i := 0;
             repeat
                 i += 1;
@@ -581,7 +581,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
             // Validate that the Table No involved is ON this endpoint's list of Config Lines
             if ConfigCode <> '' then begin // In the off chance someone is using the Deprecated old version with no config, we'll have to skip this check
                 DBChildLine.SetRange("Config. Code", ConfigCode);
-                DBChildLine.setRange("Source Table", TempSPBDBraiderFilters."Table No.");
+                DBChildLine.SetRange("Source Table", TempSPBDBraiderFilters."Table No.");
                 if DBChildLine.IsEmpty() and not AllObjWithCaption.IsEmpty() then begin
                     ProblemWithFilter := true;
                     TempSPBDBraiderFilters."Table No." := 0;

--- a/SBIDataBraider_APP/src/EngineOperations/SPBDBraiderDataEngine.Codeunit.al
+++ b/SBIDataBraider_APP/src/EngineOperations/SPBDBraiderDataEngine.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 AddDataFromConfigLine(TempSPBDBraiderResultsetRowTopLevel, DBHeader, DBLine, NextRowNo, ParentLineRef);
             until DBLine.Next() = 0;
 
-        if RunForSpecificRecordRef.Number <> 0 then
+        if RunForSpecificRecordRef.Number() <> 0 then
             MarkInclusionRecords();
 
         EndTime := Time();
@@ -80,7 +80,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
             TempSPBDBraiderResultsetRow.Reset();
         end;
 
-        DBHeader.RegisterReadUsage(TempSPBDBraiderResultsetRow.Count);
+        DBHeader.RegisterReadUsage(TempSPBDBraiderResultsetRow.Count());
         SPBDBraiderEvents.OnAfterGenerateData(DBHeader, TempSPBDBraiderResultsetRow, TempSPBDBraiderResultsetCol);
     end;
 
@@ -151,9 +151,9 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 TempSPBDBraiderResultsetCol."Field Name" := CopyStr(FldRef.Name(), 1, MaxStrLen(TempSPBDBraiderResultsetCol."Field Name"));
                 if DBField."Manual Field Caption" <> '' then
                     TempSPBDBraiderResultsetCol."Forced Field Caption" := DBField."Manual Field Caption";
-                TempSPBDBraiderResultsetCol."Value as Text" := Format(FldRef.Value);
-                TempSPBDBraiderResultsetCol."Source SystemId" := LineRef.Field(LineRef.SystemIdNo).Value;
-                TempSPBDBraiderResultsetCol."Source Table" := LineRef.Number;
+                TempSPBDBraiderResultsetCol."Value as Text" := Format(FldRef.Value());
+                TempSPBDBraiderResultsetCol."Source SystemId" := LineRef.Field(LineRef.SystemIdNo()).Value();
+                TempSPBDBraiderResultsetCol."Source Table" := LineRef.Number();
                 TempSPBDBraiderResultsetCol."Field Class" := DBField."Field Class";
                 if IsNullGuid(TopLevelRecordId) then
                     TempSPBDBraiderResultsetCol."Top-Level SystemId" := TempSPBDBraiderResultsetRow."Source SystemId"
@@ -166,16 +166,16 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 TempSPBDBraiderResultsetCol."Data Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FldRef.Type());
                 case TempSPBDBraiderResultsetCol."Data Type" of
                     Enum::"SPB DBraider Field Data Type"::Boolean:
-                        TempSPBDBraiderResultsetCol.BooleanCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.BooleanCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Code:
-                        TempSPBDBraiderResultsetCol.CodeCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.CodeCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Date:
-                        TempSPBDBraiderResultsetCol.DateCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.DateCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Time:
-                        TempSPBDBraiderResultsetCol.TimeCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.TimeCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Datetime:
                         begin
-                            ThisDateTime := FldRef.Value;
+                            ThisDateTime := FldRef.Value();
                             if DBField."DateTime Timezone" <> '' then
                                 ThisDateTime := TypeHelper.ConvertDateTimeFromUTCToTimeZone(ThisDateTime, DBField."DateTime Timezone");
                             TempSPBDBraiderResultsetCol.DatetimeCell := ThisDateTime;
@@ -183,19 +183,19 @@ codeunit 71033600 "SPB DBraider Data Engine"
                             TempSPBDBraiderResultsetCol."Value as Text" := Format(FldRef);
                         end;
                     Enum::"SPB DBraider Field Data Type"::Decimal:
-                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Integer:
-                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Option:
-                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.NumberCell := FldRef.Value();
                     Enum::"SPB DBraider Field Data Type"::Guid:
-                        TempSPBDBraiderResultsetCol.GuidCell := FldRef.Value;
+                        TempSPBDBraiderResultsetCol.GuidCell := FldRef.Value();
                 end;
-                TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number <> 0) and (RunForSpecificRecordRef.Number = LineRef.Number);
+                TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number() <> 0) and (RunForSpecificRecordRef.Number() = LineRef.Number());
                 TempSPBDBraiderResultsetCol.Insert(true);
 
                 if (not SPBDBraiderSetup."Disable Related Id") then begin //or (not DBHeader."Disable Related Id") then begin
-                    VirtualField.Get(LineRef.Number, FldRef.Number());
+                    VirtualField.Get(LineRef.Number(), FldRef.Number());
                     if VirtualField.RelationTableNo <> 0 then begin
                         RelatedTableRef.Open(VirtualField.RelationTableNo);
                         if VirtualField.RelationFieldNo <> 0 then
@@ -204,15 +204,15 @@ codeunit 71033600 "SPB DBraider Data Engine"
                             RelatedTablePrimaryKeyFields := SPBDBraiderUtilities.GetPrimaryKeyFields(RelatedTableRef);
                             RelatedTableFieldRef := RelatedTableRef.Field(RelatedTablePrimaryKeyFields.Get(RelatedTablePrimaryKeyFields.Count()));
                         end;
-                        RelatedTableFieldRef.SetRange(Format(FldRef.Value));
-                        RelatedTableSystemIdFieldRef := RelatedTableRef.Field(RelatedTableRef.SystemIdNo);
+                        RelatedTableFieldRef.SetRange(Format(FldRef.Value()));
+                        RelatedTableSystemIdFieldRef := RelatedTableRef.Field(RelatedTableRef.SystemIdNo());
                         if RelatedTableRef.FindFirst() then begin
                             // we'll add the Id version of the field to the columns dataset
                             TempSPBDBraiderResultsetCol2 := TempSPBDBraiderResultsetCol;
                             TempSPBDBraiderResultsetCol2."Data Type" := Enum::"SPB DBraider Field Data Type"::RelatedId;
                             TempSPBDBraiderResultsetCol2."Column No." := NextColNo - 1 + 1900000000;
-                            TempSPBDBraiderResultsetCol2."Value as Text" := CopyStr(Format(RelatedTableSystemIdFieldRef.Value, 0, 4).ToLower(), 1, MaxStrLen(TempSPBDBraiderResultsetCol2."Value as Text"));
-                            TempSPBDBraiderResultsetCol2.GuidCell := RelatedTableSystemIdFieldRef.Value;
+                            TempSPBDBraiderResultsetCol2."Value as Text" := CopyStr(Format(RelatedTableSystemIdFieldRef.Value(), 0, 4).ToLower(), 1, MaxStrLen(TempSPBDBraiderResultsetCol2."Value as Text"));
+                            TempSPBDBraiderResultsetCol2.GuidCell := RelatedTableSystemIdFieldRef.Value();
                             TempSPBDBraiderResultsetCol := TempSPBDBraiderResultsetCol2;
                             TempSPBDBraiderResultsetCol.Insert(true);
                         end;
@@ -268,7 +268,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
         DBField.SetRange("Filter");
 
         // Check if we need to apply extra filters applied from external calls
-        if RunForSpecificRecordRef.Number = LineRef.Number then begin
+        if RunForSpecificRecordRef.Number() = LineRef.Number() then begin
             LineRef.FilterGroup(10);
             CopyFiltersFromRecRefToRecRef(RunForSpecificRecordRef, LineRef);
             LineRef.FilterGroup(0);
@@ -296,7 +296,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
                     // Apply each relationship filter
                     ParentFldRef := ParentLineRef.Field(DBRelation."Parent Field No.");
                     FldRef := LineRef.Field(DBRelation."Child Field No.");
-                    FldRef.SetFilter(Format(ParentFldRef.Value));
+                    FldRef.SetFilter(Format(ParentFldRef.Value()));
                 until DBRelation.Next() = 0;
         end;
 
@@ -346,7 +346,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 TempSPBDBraiderResultsetRow."Header Row" := false;
                 TempSPBDBraiderResultsetRow."Source Table" := DBLine."Source Table";
                 TempSPBDBraiderResultsetRow."Primary Key String" := CopyStr(LineRef.GetPosition(true), 1, MaxStrLen(TempSPBDBraiderResultsetRow."Primary Key String"));
-                TempSPBDBraiderResultsetRow."Source SystemId" := LineRef.Field(LineRef.SystemIdNo).Value;
+                TempSPBDBraiderResultsetRow."Source SystemId" := LineRef.Field(LineRef.SystemIdNo()).Value();
                 TempSPBDBraiderResultsetRow."Belongs To Row No." := TempSPBDBraiderResultsetRowTopLevel."Row No.";
                 if TempSPBDBraiderResultsetRow."Belongs To Row No." = 0 then
                     // "top level" record
@@ -356,10 +356,10 @@ codeunit 71033600 "SPB DBraider Data Engine"
                     TempSPBDBraiderResultsetRow."Top-Level SystemId" := TempSPBDBraiderResultsetRowTopLevel."Source SystemId";
                 TempSPBDBraiderResultsetRow."Config. Code" := DBLine."Config. Code";
                 TempSPBDBraiderResultsetRow."FQ SystemId" := CopyStr(SPBDBraiderUtilities.BuildFQSI(BreadcrumbRecordRefArray, DBLine.Indentation + 1), 1, MaxStrLen(TempSPBDBraiderResultsetRow."FQ SystemId"));
-                if (RunForSpecificRecordRef.Number <> 0) then begin
+                if (RunForSpecificRecordRef.Number() <> 0) then begin
                     // if we're running for a specific record, it's from the write engine.
                     TempSPBDBraiderResultsetRow."Data Mode" := TempSPBDBraiderResultsetRow."Data Mode"::Write;
-                    if (RunForSpecificRecordRef.Number = LineRef.Number) then
+                    if (RunForSpecificRecordRef.Number() = LineRef.Number()) then
                         if TempSPBDBraiderResultsetRow."Belongs To Row No." = 0 then
                             TempSPBDBraiderResultsetRow."Buffer Type" := Enum::"SPB DBraider Buffer Type"::Direct
                         else
@@ -411,7 +411,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
         SPBDBraiderConfLineFlow.SetRange("Config. Code", DBLine."Config. Code");
         SPBDBraiderConfLineFlow.SetRange("Config. Line No.", DBLine."Line No.");
         SPBDBraiderConfLineFlow.SetFilter("Parent Table No.", '<>%1', 0);
-        if SPBDBraiderConfLineFlow.IsEmpty then
+        if SPBDBraiderConfLineFlow.IsEmpty() then
             exit;
 
         // for each flow field setting
@@ -419,7 +419,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
             repeat
                 // Cycle through the breadcrumb array to find the parent record, matching on the Parent Table No.
                 for i := (DBLine.Indentation + 1) downto 1 do
-                    if BreadcrumbRecordRefArray[i].Number = SPBDBraiderConfLineFlow."Parent Table No." then begin
+                    if BreadcrumbRecordRefArray[i].Number() = SPBDBraiderConfLineFlow."Parent Table No." then begin
                         FlowFieldSourceRecordRef := BreadcrumbRecordRefArray[i].Duplicate();
                         FlowFieldSourceFound := true;
                     end;
@@ -431,7 +431,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 SPBDBraiderConfLineFlow.Reset();
                 SPBDBraiderConfLineFlow.SetRange("Config. Code", BreadcrumbRecordConfigLine[i]."Config. Code");
                 SPBDBraiderConfLineFlow.SetRange("Config. Line No.", BreadcrumbRecordConfigLine[i]."Line No.");
-                SPBDBraiderConfLineFlow.SetRange("Parent Table No.", FlowFieldSourceRecordRef.Number);
+                SPBDBraiderConfLineFlow.SetRange("Parent Table No.", FlowFieldSourceRecordRef.Number());
                 if SPBDBraiderConfLineFlow.FindSet() then
                     repeat
                         // For the target FlowFilter for the Parent based on this configFlow entry
@@ -439,7 +439,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
 
                         // The value of the filter comes from the value of that relevant record's field source, based on our "i" level
                         FilterValueFieldRef := BreadcrumbRecordRefArray[i].Field(SPBDBraiderConfLineFlow."Source FlowFilter Field No.");
-                        ParentFlowFilterFieldRef.SetFilter(FilterValueFieldRef.Value);
+                        ParentFlowFilterFieldRef.SetFilter(FilterValueFieldRef.Value());
                     until SPBDBraiderConfLineFlow.Next() < 1;
             end;
 
@@ -458,10 +458,10 @@ codeunit 71033600 "SPB DBraider Data Engine"
         ToFieldRef: FieldRef;
         i: Integer;
     begin
-        for i := 1 to WhichRecordRef.FieldCount do begin
+        for i := 1 to WhichRecordRef.FieldCount() do begin
             FromFieldRef := WhichRecordRef.FieldIndex(i);
             ToFieldRef := LineRef.FieldIndex(i);
-            ToFieldRef.SetFilter(FromFieldRef.GetFilter);
+            ToFieldRef.SetFilter(FromFieldRef.GetFilter());
         end;
     end;
 
@@ -489,9 +489,9 @@ codeunit 71033600 "SPB DBraider Data Engine"
         if (not DBHeader."Disable Auto ModifiedAt") and (not SPBDBraiderSetup."Disable Auto ModifiedAt") then begin
             // TimestampInMilliseconds := Timestamp * 1000;
             // ResultDateTime := EpochDateTime + TimestampInMilliseconds + TimezoneOffset;
-            ModifiedFieldRef := LineRef.Field(LineRef.SystemModifiedAtNo);
+            ModifiedFieldRef := LineRef.Field(LineRef.SystemModifiedAtNo());
             //Evaluate(RecordDateTime, ModifiedFieldRef.Value);
-            RecordDateTime := ModifiedFieldRef.Value;
+            RecordDateTime := ModifiedFieldRef.Value();
 
             // For pre-BC databases that upgraded, this field CAN be empty, so skip if so
             if RecordDateTime <> 0DT then begin
@@ -499,7 +499,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
 
                 TempSPBDBraiderResultsetCol.Init();
                 TempSPBDBraiderResultsetCol."Row No." := TempSPBDBraiderResultsetRow."Row No.";
-                TempSPBDBraiderResultsetCol."Column No." := LineRef.SystemModifiedAtNo;
+                TempSPBDBraiderResultsetCol."Column No." := LineRef.SystemModifiedAtNo();
                 TempSPBDBraiderResultsetCol."Field Name" := 'lastModifiedAt';
                 TempSPBDBraiderResultsetCol."Field No." := ModifiedFieldRef.Number();
                 TempSPBDBraiderResultsetCol."Value as Text" := Format(TimestampInMilliseconds);
@@ -507,7 +507,7 @@ codeunit 71033600 "SPB DBraider Data Engine"
                 TempSPBDBraiderResultsetCol."Data Type" := TempSPBDBraiderResultsetCol."Data Type"::Integer;
                 TempSPBDBraiderResultsetCol."Source SystemId" := TempSPBDBraiderResultsetRow."Source SystemId";
                 TempSPBDBraiderResultsetCol."Top-Level SystemId" := TempSPBDBraiderResultsetRow."Top-Level SystemId";
-                TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number <> 0) and (RunForSpecificRecordRef.Number = LineRef.Number);
+                TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number() <> 0) and (RunForSpecificRecordRef.Number() = LineRef.Number());
                 TempSPBDBraiderResultsetCol.Insert(true);
             end;
         end;
@@ -515,15 +515,15 @@ codeunit 71033600 "SPB DBraider Data Engine"
         if (not DBHeader."Disable Auto SystemId") and (not SPBDBraiderSetup."Disable Auto SystemId") then begin
             TempSPBDBraiderResultsetCol.Init();
             TempSPBDBraiderResultsetCol."Row No." := TempSPBDBraiderResultsetRow."Row No.";
-            TempSPBDBraiderResultsetCol."Column No." := LineRef.SystemIdNo;
+            TempSPBDBraiderResultsetCol."Column No." := LineRef.SystemIdNo();
             TempSPBDBraiderResultsetCol."Field Name" := 'systemId';
-            TempSPBDBraiderResultsetCol."Field No." := LineRef.SystemIdNo;
-            TempSPBDBraiderResultsetCol."Value as Text" := CopyStr(Format(LineRef.Field(LineRef.SystemIdNo).Value, 0, 4).ToLower(), 1, MaxStrLen(TempSPBDBraiderResultsetCol."Value as Text"));
-            TempSPBDBraiderResultsetCol.GuidCell := LineRef.Field(LineRef.SystemIdNo).Value;
+            TempSPBDBraiderResultsetCol."Field No." := LineRef.SystemIdNo();
+            TempSPBDBraiderResultsetCol."Value as Text" := CopyStr(Format(LineRef.Field(LineRef.SystemIdNo()).Value(), 0, 4).ToLower(), 1, MaxStrLen(TempSPBDBraiderResultsetCol."Value as Text"));
+            TempSPBDBraiderResultsetCol.GuidCell := LineRef.Field(LineRef.SystemIdNo()).Value();
             TempSPBDBraiderResultsetCol."Data Type" := TempSPBDBraiderResultsetCol."Data Type"::Guid;
             TempSPBDBraiderResultsetCol."Source SystemId" := TempSPBDBraiderResultsetRow."Source SystemId";
             TempSPBDBraiderResultsetCol."Top-Level SystemId" := TempSPBDBraiderResultsetRow."Top-Level SystemId";
-            TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number <> 0) and (RunForSpecificRecordRef.Number = LineRef.Number);
+            TempSPBDBraiderResultsetCol."Write Result Record" := (RunForSpecificRecordRef.Number() <> 0) and (RunForSpecificRecordRef.Number() = LineRef.Number());
             TempSPBDBraiderResultsetCol.Insert(true);
         end;
     end;

--- a/SBIDataBraider_APP/src/EventNotifications/SPBDBraiderEventNoteMgt.Codeunit.al
+++ b/SBIDataBraider_APP/src/EventNotifications/SPBDBraiderEventNoteMgt.Codeunit.al
@@ -7,7 +7,7 @@ codeunit 71033628 "SPB DBraider Event Note Mgt"
         EventNote: Record "SPBDBraider Event Notification";
         NextLineNo: Integer;
 
-    internal procedure CreateEventNote(DBConfigCode: Code[20]; TableID: Integer; RecID: RecordId; ActionType: text; DeletedPK: Text)
+    internal procedure CreateEventNote(DBConfigCode: Code[20]; TableID: Integer; RecID: RecordId; ActionType: Text; DeletedPK: Text)
     begin
         if EventNote.FindLast() then
             NextLineNo := EventNote.LineNo + 1

--- a/SBIDataBraider_APP/src/EventNotifications/SPBDBraiderEventNoteMgt.Codeunit.al
+++ b/SBIDataBraider_APP/src/EventNotifications/SPBDBraiderEventNoteMgt.Codeunit.al
@@ -7,7 +7,7 @@ codeunit 71033628 "SPB DBraider Event Note Mgt"
         EventNote: Record "SPBDBraider Event Notification";
         NextLineNo: Integer;
 
-    internal procedure CreateEventNote(DBConfigCode: Code[20]; TableID: Integer; RecID: RecordId; ActionType: text; DeletedPK: Text);
+    internal procedure CreateEventNote(DBConfigCode: Code[20]; TableID: Integer; RecID: RecordId; ActionType: text; DeletedPK: Text)
     begin
         if EventNote.FindLast() then
             NextLineNo := EventNote.LineNo + 1

--- a/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
+++ b/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
@@ -4,57 +4,57 @@ codeunit 71033619 "SPB DBraider Events"
     /* Since API calls are SUPPOSED to be fast, subscribers should take caution to add any extra DB operations */
 
     [IntegrationEvent(false, false)]
-    procedure OnBeforeGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
+    local procedure OnBeforeGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var TempSPBDBraiderResultsetRow: Record "SPB DBraider Resultset Row" temporary; var TempSPBDBraiderResultsetCol: Record "SPB DBraider Resultset Col" temporary)
+    local procedure OnAfterGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var TempSPBDBraiderResultsetRow: Record "SPB DBraider Resultset Row" temporary; var TempSPBDBraiderResultsetCol: Record "SPB DBraider Resultset Col" temporary)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterFormatData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonResult: Text)
+    local procedure OnAfterFormatData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonResult: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnBeforeWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
+    local procedure OnBeforeWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text; var JsonResult: Text; Success: Boolean)
+    local procedure OnAfterWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text; var JsonResult: Text; Success: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterWritetoEventNotification(EventNote: Record "SPBDBraider Event Notification")
+    local procedure OnAfterWritetoEventNotification(EventNote: Record "SPBDBraider Event Notification")
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnBeforeConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
+    local procedure OnBeforeConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
+    local procedure OnAfterConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnBeforeMapFieldTypeToSPBFieldDataType(var IsHandled: Boolean; SourceFieldType: FieldType; var SPBFieldDataType: Enum "SPB DBraider Field Data Type")
+    local procedure OnBeforeMapFieldTypeToSPBFieldDataType(var IsHandled: Boolean; SourceFieldType: FieldType; var SPBFieldDataType: Enum "SPB DBraider Field Data Type")
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnUnhandledPostmanEndpointType(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var isHandled: Boolean)
+    local procedure OnUnhandledPostmanEndpointType(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var isHandled: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnSupportWizardChecksStarting(var TempSPBDBraiderConfigHeader: Record "SPB DBraider Config. Header" temporary; var TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary)
+    local procedure OnSupportWizardChecksStarting(var TempSPBDBraiderConfigHeader: Record "SPB DBraider Config. Header" temporary; var TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary)
     begin
     end;
 }

--- a/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
+++ b/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
@@ -1,60 +1,59 @@
 codeunit 71033619 "SPB DBraider Events"
 {
-    Access = Internal;
     /* Since API calls are SUPPOSED to be fast, subscribers should take caution to add any extra DB operations */
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
+    internal procedure OnBeforeGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var TempSPBDBraiderResultsetRow: Record "SPB DBraider Resultset Row" temporary; var TempSPBDBraiderResultsetCol: Record "SPB DBraider Resultset Col" temporary)
+    internal procedure OnAfterGenerateData(var DBHeader: Record "SPB DBraider Config. Header"; var TempSPBDBraiderResultsetRow: Record "SPB DBraider Resultset Row" temporary; var TempSPBDBraiderResultsetCol: Record "SPB DBraider Resultset Col" temporary)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterFormatData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonResult: Text)
+    internal procedure OnAfterFormatData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonResult: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
+    internal procedure OnBeforeWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text; var JsonResult: Text; Success: Boolean)
+    internal procedure OnAfterWriteData(var DBHeader: Record "SPB DBraider Config. Header"; var JsonInput: Text; var JsonResult: Text; Success: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterWritetoEventNotification(EventNote: Record "SPBDBraider Event Notification")
+    internal procedure OnAfterWritetoEventNotification(EventNote: Record "SPBDBraider Event Notification")
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
+    internal procedure OnBeforeConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
+    internal procedure OnAfterConvertJSONtoText(var ConfigCode: Code[20]; var JsonRows: JsonArray; var ResultText: Text)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeMapFieldTypeToSPBFieldDataType(var IsHandled: Boolean; SourceFieldType: FieldType; var SPBFieldDataType: Enum "SPB DBraider Field Data Type")
+    internal procedure OnBeforeMapFieldTypeToSPBFieldDataType(var IsHandled: Boolean; SourceFieldType: FieldType; var SPBFieldDataType: Enum "SPB DBraider Field Data Type")
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnUnhandledPostmanEndpointType(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var isHandled: Boolean)
+    internal procedure OnUnhandledPostmanEndpointType(var SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var isHandled: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnSupportWizardChecksStarting(var TempSPBDBraiderConfigHeader: Record "SPB DBraider Config. Header" temporary; var TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary)
+    internal procedure OnSupportWizardChecksStarting(var TempSPBDBraiderConfigHeader: Record "SPB DBraider Config. Header" temporary; var TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary)
     begin
     end;
 }

--- a/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
+++ b/SBIDataBraider_APP/src/Extensibility/SPBDBraiderEvents.Codeunit.al
@@ -1,5 +1,6 @@
 codeunit 71033619 "SPB DBraider Events"
 {
+    Access = Public;
     /* Since API calls are SUPPOSED to be fast, subscribers should take caution to add any extra DB operations */
 
     [IntegrationEvent(false, false)]

--- a/SBIDataBraider_APP/src/Licensing/Usage/SPBDBraiderUsage.Table.al
+++ b/SBIDataBraider_APP/src/Licensing/Usage/SPBDBraiderUsage.Table.al
@@ -9,27 +9,22 @@ table 71033608 "SPB DBraider Usage"
         field(1; "Endpoint Id"; Guid)
         {
             Caption = 'Endpoint Id';
-            DataClassification = SystemMetadata;
         }
         field(2; "Month Start Date"; Date)
         {
             Caption = 'Month Start Date';
-            DataClassification = SystemMetadata;
         }
         field(10; "Call Tally"; Integer)
         {
             Caption = 'Call Tally';
-            DataClassification = SystemMetadata;
         }
         field(20; "Rows Read"; BigInteger)
         {
             Caption = 'Rows Read';
-            DataClassification = SystemMetadata;
         }
         field(21; "Rows Written"; BigInteger)
         {
             Caption = 'Rows Written';
-            DataClassification = SystemMetadata;
         }
     }
     keys

--- a/SBIDataBraider_APP/src/Previews/SPBDBraiderLargeTextView.Page.al
+++ b/SBIDataBraider_APP/src/Previews/SPBDBraiderLargeTextView.Page.al
@@ -14,7 +14,6 @@ page 71033616 "SPB DBraider Large Text View"
         {
             field(dynamicCaptionField; DynamicCaption)
             {
-                ApplicationArea = All;
                 Editable = false;
                 MultiLine = true;
                 ShowCaption = false;

--- a/SBIDataBraider_APP/src/Previews/SPBDBraiderResultSubpage.Page.al
+++ b/SBIDataBraider_APP/src/Previews/SPBDBraiderResultSubpage.Page.al
@@ -39,7 +39,7 @@ page 71033606 "SPB DBraider Result Subpage"
 
     procedure SetTempData(var ResultCol: Record "SPB DBraider Resultset Col" temporary)
     begin
-        if not Rec.IsTemporary then
+        if not Rec.IsTemporary() then
             exit;
 
         Rec.DeleteAll();

--- a/SBIDataBraider_APP/src/Previews/SPBDBraiderResults.Page.al
+++ b/SBIDataBraider_APP/src/Previews/SPBDBraiderResults.Page.al
@@ -76,7 +76,7 @@ page 71033605 "SPB DBraider Results"
 
     procedure SetTempData(var RowData: Record "SPB DBraider Resultset Row" temporary; var ColData: Record "SPB DBraider Resultset Col" temporary)
     begin
-        if not Rec.IsTemporary then
+        if not Rec.IsTemporary() then
             exit;
 
         Rec.DeleteAll();

--- a/SBIDataBraider_APP/src/ROI/SPBDBraiderROIBuilder.Codeunit.al
+++ b/SBIDataBraider_APP/src/ROI/SPBDBraiderROIBuilder.Codeunit.al
@@ -157,7 +157,7 @@ codeunit 71033629 "SPB DBraider ROI Builder"
         SPBDBraiderConfigLine: Record "SPB DBraider Config. Line";
     begin
         SPBDBraiderConfigLine.SetRange("Config. Code", SPBDBraiderConfigHeader.Code);
-        if SPBDBraiderConfigLine.Count = 1 then begin
+        if SPBDBraiderConfigLine.Count() = 1 then begin
             SPBDBraiderConfigLine.FindFirst();
             CalculateFieldROI(SPBDBraiderConfigHeader, EndpointHeaderLineNo, SPBDBraiderConfigLine);
             exit;

--- a/SBIDataBraider_APP/src/SupportWizard/Checks/SPBDBSuppEndpointCheck.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Checks/SPBDBSuppEndpointCheck.Codeunit.al
@@ -133,7 +133,7 @@ codeunit 71033624 "SPB DB Supp - Endpoint Check"
         if SPBDBraiderConfigHeader.Get(Rec."Endpoint Code") then begin
             SPBDBraiderConfLine.SetRange(SPBDBraiderConfLine."Config. Code", SPBDBraiderConfigHeader."Code");
             // if there is only 1 config line, then there are no relationships, and we can mark this as a Skipped test
-            if SPBDBraiderConfLine.Count = 1 then
+            if SPBDBraiderConfLine.Count() = 1 then
                 RegisterSkipped(Rec)
             else begin
                 SPBDBraiderConfLine.SetFilter(Indentation, '>0');

--- a/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
@@ -10,7 +10,7 @@ page 71033618 "SPB Braider Support Wizard"
 
     layout
     {
-        area(content)
+        area(Content)
         {
             group(StandardBanner)
             {
@@ -153,7 +153,7 @@ page 71033618 "SPB Braider Support Wizard"
     }
     actions
     {
-        area(processing)
+        area(Processing)
         {
             action(ActionBack)
             {
@@ -282,7 +282,7 @@ page 71033618 "SPB Braider Support Wizard"
     begin
         if Backwards then
             Step := Step - 1
-        ELSE
+        else
             Step := Step + 1;
 
         EnableControls();
@@ -344,11 +344,11 @@ page 71033618 "SPB Braider Support Wizard"
 
     local procedure LoadTopBanners()
     begin
-        if MediaRepositoryStandard.GET('AssistedSetup-NoText-400px.png', FORMAT(CurrentClientType())) AND
-           MediaRepositoryDone.GET('AssistedSetupDone-NoText-400px.png', FORMAT(CurrentClientType()))
+        if MediaRepositoryStandard.Get('AssistedSetup-NoText-400px.png', Format(CurrentClientType())) and
+           MediaRepositoryDone.Get('AssistedSetupDone-NoText-400px.png', Format(CurrentClientType()))
         then
-            if MediaResourcesStandard.GET(MediaRepositoryStandard."Media Resources Ref") AND
-               MediaResourcesDone.GET(MediaRepositoryDone."Media Resources Ref")
+            if MediaResourcesStandard.Get(MediaRepositoryStandard."Media Resources Ref") and
+               MediaResourcesDone.Get(MediaRepositoryDone."Media Resources Ref")
             then
                 TopBannerVisible := MediaResourcesDone."Media Reference".HasValue();
     end;
@@ -356,9 +356,9 @@ page 71033618 "SPB Braider Support Wizard"
     local procedure ValidateCaseDetails() Valid: Boolean
     begin
         // Check all the case values to ensure they have a value, setting Valid to true if they are all filled in
-        Valid := (CaseDescription <> '') AND
-                 (CaseSeverity <> CaseSeverity::" ") AND
-                 (CaseContactName <> '') AND
+        Valid := (CaseDescription <> '') and
+                 (CaseSeverity <> CaseSeverity::" ") and
+                 (CaseContactName <> '') and
                  (CaseEmail <> '');
     end;
 

--- a/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
@@ -14,7 +14,7 @@ page 71033618 "SPB Braider Support Wizard"
         {
             group(StandardBanner)
             {
-                Caption = '';
+                Caption = '', Locked = true;
                 Editable = false;
                 Visible = TopBannerVisible and not SubmitActionEnabled;
                 field(MediaResourcesStandard; MediaResourcesStandard."Media Reference")
@@ -26,7 +26,7 @@ page 71033618 "SPB Braider Support Wizard"
             }
             group(SubmitedBanner)
             {
-                Caption = '';
+                Caption = '', Locked = true;
                 Editable = false;
                 Visible = TopBannerVisible and SubmitActionEnabled;
                 field(MediaResourcesDone; MediaResourcesDone."Media Reference")

--- a/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/SPBBraiderSupportWizard.Page.al
@@ -106,7 +106,7 @@ page 71033618 "SPB Braider Support Wizard"
                         ShowMandatory = true;
                         ToolTip = 'Please provide a detailed description of the issue you are experiencing';
 
-                        trigger OnValidate();
+                        trigger OnValidate()
                         begin
                             CheckIfSubmitReady();
                         end;
@@ -118,7 +118,7 @@ page 71033618 "SPB Braider Support Wizard"
                         OptionCaption = ' ,Critical - Production Stopped,High - Production Impacted,Medium - Production Partially Impacted,Low - No Production Impact';
                         ToolTip = 'Please select the severity of the issue';
 
-                        trigger OnValidate();
+                        trigger OnValidate()
                         begin
                             CheckIfSubmitReady();
                         end;
@@ -130,7 +130,7 @@ page 71033618 "SPB Braider Support Wizard"
                         ShowMandatory = true;
                         ToolTip = 'Please provide a name for the case contact';
 
-                        trigger OnValidate();
+                        trigger OnValidate()
                         begin
                             CheckIfSubmitReady();
                         end;
@@ -142,7 +142,7 @@ page 71033618 "SPB Braider Support Wizard"
                         ShowMandatory = true;
                         ToolTip = 'Please provide an email address for the case contact';
 
-                        trigger OnValidate();
+                        trigger OnValidate()
                         begin
                             CheckIfSubmitReady();
                         end;
@@ -162,7 +162,7 @@ page 71033618 "SPB Braider Support Wizard"
                 Enabled = BackActionEnabled;
                 Image = PreviousRecord;
                 InFooterBar = true;
-                trigger OnAction();
+                trigger OnAction()
                 begin
                     NextStep(true);
                 end;
@@ -174,7 +174,7 @@ page 71033618 "SPB Braider Support Wizard"
                 Enabled = NextActionEnabled;
                 Image = NextRecord;
                 InFooterBar = true;
-                trigger OnAction();
+                trigger OnAction()
                 begin
                     NextStep(false);
                 end;
@@ -186,19 +186,19 @@ page 71033618 "SPB Braider Support Wizard"
                 Enabled = SubmitActionEnabled;
                 Image = Approve;
                 InFooterBar = true;
-                trigger OnAction();
+                trigger OnAction()
                 begin
                     SubmitAction();
                 end;
             }
         }
     }
-    trigger OnInit();
+    trigger OnInit()
     begin
         LoadTopBanners();
     end;
 
-    trigger OnOpenPage();
+    trigger OnOpenPage()
     var
         SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header";
     begin
@@ -245,7 +245,7 @@ page 71033618 "SPB Braider Support Wizard"
         MediaResourcesStandard: Record "Media Resources";
         SPBDBraiderWizState: Codeunit "SPB DBraider Wiz State";
 
-    local procedure EnableControls();
+    local procedure EnableControls()
     begin
         ResetControls();
 
@@ -261,7 +261,7 @@ page 71033618 "SPB Braider Support Wizard"
         end;
     end;
 
-    local procedure SubmitAction();
+    local procedure SubmitAction()
     var
         TempSelectedEndpoints: Record "SPB DBraider Config. Header" temporary;
         TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary;
@@ -278,7 +278,7 @@ page 71033618 "SPB Braider Support Wizard"
         CurrPage.Close();
     end;
 
-    local procedure NextStep(Backwards: Boolean);
+    local procedure NextStep(Backwards: Boolean)
     begin
         if Backwards then
             Step := Step - 1
@@ -288,7 +288,7 @@ page 71033618 "SPB Braider Support Wizard"
         EnableControls();
     end;
 
-    local procedure ShowStep1();
+    local procedure ShowStep1()
     begin
         Step1Visible := true;
 
@@ -296,12 +296,12 @@ page 71033618 "SPB Braider Support Wizard"
         BackActionEnabled := false;
     end;
 
-    local procedure ShowStep2();
+    local procedure ShowStep2()
     begin
         Step2Visible := true;
     end;
 
-    local procedure ShowStep3();
+    local procedure ShowStep3()
     var
         TempSelectedEndpoints: Record "SPB DBraider Config. Header" temporary;
         TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary;
@@ -320,7 +320,7 @@ page 71033618 "SPB Braider Support Wizard"
         Step3Visible := true;
     end;
 
-    local procedure ShowStep4();
+    local procedure ShowStep4()
     begin
         Step4Visible := true;
 
@@ -330,7 +330,7 @@ page 71033618 "SPB Braider Support Wizard"
         SubmitActionEnabled := true;
     end;
 
-    local procedure ResetControls();
+    local procedure ResetControls()
     begin
         SubmitActionEnabled := false;
         BackActionEnabled := true;
@@ -342,7 +342,7 @@ page 71033618 "SPB Braider Support Wizard"
         Step4Visible := false;
     end;
 
-    local procedure LoadTopBanners();
+    local procedure LoadTopBanners()
     begin
         if MediaRepositoryStandard.GET('AssistedSetup-NoText-400px.png', FORMAT(CurrentClientType())) AND
            MediaRepositoryDone.GET('AssistedSetupDone-NoText-400px.png', FORMAT(CurrentClientType()))

--- a/SBIDataBraider_APP/src/SupportWizard/SPBDBraiderWizState.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/SPBDBraiderWizState.Codeunit.al
@@ -7,7 +7,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
         TempSelectedEndpoints: Record "SPB DBraider Config. Header" temporary;
         TempSPBDBraiderWizChecks: Record "SPB DBraider WizChecks" temporary;
 
-    procedure SetSelectedEndpoints(var NewSelectedEndpoints: Record "SPB DBraider Config. Header");
+    procedure SetSelectedEndpoints(var NewSelectedEndpoints: Record "SPB DBraider Config. Header")
     begin
         if not TempSelectedEndpoints.IsTemporary then
             exit;
@@ -20,7 +20,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
         if TempSelectedEndpoints.FindFirst() then;
     end;
 
-    procedure GetSelectedEndpoints(var NewSelectedEndpoints: Record "SPB DBraider Config. Header");
+    procedure GetSelectedEndpoints(var NewSelectedEndpoints: Record "SPB DBraider Config. Header")
     begin
         NewSelectedEndpoints.DeleteAll();
         if TempSelectedEndpoints.FindSet() then
@@ -30,7 +30,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
             until TempSelectedEndpoints.Next() < 1;
     end;
 
-    procedure SetSPBDBraiderWizChecks(var SPBDBraiderWizChecks: Record "SPB DBraider WizChecks");
+    procedure SetSPBDBraiderWizChecks(var SPBDBraiderWizChecks: Record "SPB DBraider WizChecks")
     begin
         if not TempSPBDBraiderWizChecks.IsTemporary then
             exit;
@@ -43,7 +43,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
         if TempSPBDBraiderWizChecks.FindFirst() then;
     end;
 
-    procedure GetSPBDBraiderWizChecks(var SPBDBraiderWizChecks: Record "SPB DBraider WizChecks");
+    procedure GetSPBDBraiderWizChecks(var SPBDBraiderWizChecks: Record "SPB DBraider WizChecks")
     begin
         SPBDBraiderWizChecks.DeleteAll();
         if TempSPBDBraiderWizChecks.FindSet() then
@@ -53,7 +53,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
             until TempSPBDBraiderWizChecks.Next() < 1;
     end;
 
-    procedure IsWizardScanningComplete(): Boolean;
+    procedure IsWizardScanningComplete(): Boolean
     begin
         TempSPBDBraiderWizChecks.SetRange(Status, TempSPBDBraiderWizChecks.Status::" ");
         exit(TempSPBDBraiderWizChecks.IsEmpty);

--- a/SBIDataBraider_APP/src/SupportWizard/SPBDBraiderWizState.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/SPBDBraiderWizState.Codeunit.al
@@ -9,7 +9,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
 
     procedure SetSelectedEndpoints(var NewSelectedEndpoints: Record "SPB DBraider Config. Header")
     begin
-        if not TempSelectedEndpoints.IsTemporary then
+        if not TempSelectedEndpoints.IsTemporary() then
             exit;
         TempSelectedEndpoints.DeleteAll();
         if NewSelectedEndpoints.FindSet() then
@@ -32,7 +32,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
 
     procedure SetSPBDBraiderWizChecks(var SPBDBraiderWizChecks: Record "SPB DBraider WizChecks")
     begin
-        if not TempSPBDBraiderWizChecks.IsTemporary then
+        if not TempSPBDBraiderWizChecks.IsTemporary() then
             exit;
         TempSPBDBraiderWizChecks.DeleteAll();
         if SPBDBraiderWizChecks.FindSet() then
@@ -56,7 +56,7 @@ codeunit 71033626 "SPB DBraider Wiz State"
     procedure IsWizardScanningComplete(): Boolean
     begin
         TempSPBDBraiderWizChecks.SetRange(Status, TempSPBDBraiderWizChecks.Status::" ");
-        exit(TempSPBDBraiderWizChecks.IsEmpty);
+        exit(TempSPBDBraiderWizChecks.IsEmpty());
     end;
 
 }

--- a/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
@@ -269,7 +269,7 @@ codeunit 71033627 "SPB DBraider Support Submit"
         // We want to save some information from the environment to a CSV file
         WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'OnPrem', Format(EnvironmentInfo.IsOnPrem(), 0, 9));
         WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'IsProduction', Format(EnvironmentInfo.IsProduction(), 0, 9));
-        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'IsSandBox', Format(EnvironmentInfo.IsSandBox(), 0, 9));
+        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'IsSandBox', Format(EnvironmentInfo.IsSandbox(), 0, 9));
         WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'ApplicationVersion', Format(AppSysConstants.ApplicationVersion()));
         WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'ApplicationBuild', Format(AppSysConstants.ApplicationBuild()));
         WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'PlatformProductVersion', Format(AppSysConstants.PlatformProductVersion()));

--- a/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
@@ -280,8 +280,8 @@ codeunit 71033627 "SPB DBraider Support Submit"
 
         // We also want some data about Braider
         NavApp.GetCurrentModuleInfo(NavAppModuleInfo);
-        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'BraiderAppVersion', Format(NavAppModuleInfo.AppVersion));
-        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'BraiderDataVersion', Format(NavAppModuleInfo.DataVersion));
+        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'BraiderAppVersion', Format(NavAppModuleInfo.AppVersion()));
+        WriteKeyValueToCSV(TempCSVBuffer, NextLineNo, 'BraiderDataVersion', Format(NavAppModuleInfo.DataVersion()));
 
         // now add the CSV to the zip
         TempCSVBuffer.SaveDataToBlob(TempBlob, ';');
@@ -297,19 +297,19 @@ codeunit 71033627 "SPB DBraider Support Submit"
         i: Integer;
     begin
         TempCSVBuffer.Init();
-        for i := 1 to RecordRef.FieldCount do begin
+        for i := 1 to RecordRef.FieldCount() do begin
             FieldRef := RecordRef.FieldIndex(i);
-            if SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldRef.Type) <> Enum::"SPB DBraider Field Data Type"::Unsupported then begin
+            if SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldRef.Type()) <> Enum::"SPB DBraider Field Data Type"::Unsupported then begin
                 TempCSVBuffer.Init();
                 TempCSVBuffer."Line No." := i;
                 TempCSVBuffer."Field No." := 1;
-                TempCSVBuffer.Value := CopyStr(FieldRef.Name, 1, MaxStrLen(TempCSVBuffer.Value));
+                TempCSVBuffer.Value := CopyStr(FieldRef.Name(), 1, MaxStrLen(TempCSVBuffer.Value));
                 TempCSVBuffer.Insert();
 
                 TempCSVBuffer.Init();
                 TempCSVBuffer."Line No." := i;
                 TempCSVBuffer."Field No." := 2;
-                TempCSVBuffer.Value := Format(FieldRef.Value, 0, 9);
+                TempCSVBuffer.Value := Format(FieldRef.Value(), 0, 9);
                 TempCSVBuffer.Insert();
             end;
         end;
@@ -405,7 +405,7 @@ codeunit 71033627 "SPB DBraider Support Submit"
         Window.Close();
 
         if IsSuccessful then begin
-            Response.Content.ReadAs(CaseId);
+            Response.Content().ReadAs(CaseId);
             Message(SubmitSuccessMsg, CaseId);
         end else begin
             if not Confirm(SubmitFailMsg, true) then // Halting execution to let the user see what is about to happen

--- a/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderSupportSubmit.Codeunit.al
@@ -335,6 +335,7 @@ codeunit 71033627 "SPB DBraider Support Submit"
     // This function makes an API call to an SBI endpoint to submit the support case, including the ZIP file
     local procedure SendSupportRequest(CaseDescription: Text; CaseSeverity: Option; CaseContactName: Text; CaseEmail: Text; ZipFileName: Text; SupportFilesInStream: InStream)
     var
+        ConfirmManagement: Codeunit "Confirm Management";
         TempBlob: Codeunit "Temp Blob";
         IsSuccessful: Boolean;
         HttpClient: HttpClient;
@@ -408,7 +409,7 @@ codeunit 71033627 "SPB DBraider Support Submit"
             Response.Content().ReadAs(CaseId);
             Message(SubmitSuccessMsg, CaseId);
         end else begin
-            if not Confirm(SubmitFailMsg, true) then // Halting execution to let the user see what is about to happen
+            if not ConfirmManagement.GetResponseOrDefault(SubmitFailMsg, true) then // Halting execution to let the user see what is about to happen
                 exit;
             DownloadFromStream(SupportFilesInStream, 'Support Case Data File', '', '', ZipFileName);
             Hyperlink(SupportManualURITok);

--- a/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderWizSubmit.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderWizSubmit.Page.al
@@ -7,7 +7,7 @@ page 71033622 "SPB DBraider Wiz Submit"
 
     layout
     {
-        area(content)
+        area(Content)
         {
             repeater(General)
             {

--- a/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderWizSubmit.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/Submitting/SPBDBraiderWizSubmit.Page.al
@@ -25,7 +25,7 @@ page 71033622 "SPB DBraider Wiz Submit"
 
     procedure SetData(var NewRec: Record "SPB DBraider Wiz Submit")
     begin
-        if not Rec.IsTemporary then
+        if not Rec.IsTemporary() then
             exit;
         Rec.DeleteAll();
         if NewRec.FindSet() then
@@ -38,7 +38,7 @@ page 71033622 "SPB DBraider Wiz Submit"
 
     procedure GetData(var DestRec: Record "SPB DBraider Wiz Submit")
     begin
-        if not DestRec.IsTemporary then
+        if not DestRec.IsTemporary() then
             exit;
         DestRec.DeleteAll();
         if Rec.FindSet() then

--- a/SBIDataBraider_APP/src/SupportWizard/UI/SPBBraiderSWEP.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/UI/SPBBraiderSWEP.Page.al
@@ -9,7 +9,7 @@ page 71033619 "SPB Braider SW EP"
 
     layout
     {
-        area(content)
+        area(Content)
         {
             repeater(General)
             {

--- a/SBIDataBraider_APP/src/SupportWizard/UI/SPBBraiderSWEP.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/UI/SPBBraiderSWEP.Page.al
@@ -31,7 +31,7 @@ page 71033619 "SPB Braider SW EP"
 
     procedure SetData(var NewRec: Record "SPB DBraider Config. Header")
     begin
-        if not Rec.IsTemporary then
+        if not Rec.IsTemporary() then
             exit;
         Rec.DeleteAll();
         if NewRec.FindSet() then
@@ -54,7 +54,7 @@ page 71033619 "SPB Braider SW EP"
                 SelectedEndpoints.Insert();
             until Rec.Next() < 1;
         CurrPage.SetSelectionFilter(SelectedEndpoints);
-        if SelectedEndpoints.Count = 1 then begin
+        if SelectedEndpoints.Count() = 1 then begin
             SelectedEndpoints.Reset();
             SelectedEndpoints.SetPosition(SelectionPosition);
             SelectedEndpoints.SetRecFilter();

--- a/SBIDataBraider_APP/src/SupportWizard/UI/SPBSupportWizardList.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/UI/SPBSupportWizardList.Page.al
@@ -90,7 +90,7 @@ page 71033620 "SPB Support Wizard List"
 
     procedure SetData(var NewRec: Record "SPB DBraider WizChecks")
     begin
-        if not Rec.IsTemporary then
+        if not Rec.IsTemporary() then
             exit;
         Rec.DeleteAll();
         if NewRec.FindSet() then
@@ -113,7 +113,7 @@ page 71033620 "SPB Support Wizard List"
                 SelectedChecks.Insert();
             until Rec.Next() < 1;
         CurrPage.SetSelectionFilter(SelectedChecks);
-        if SelectedChecks.Count = 1 then begin
+        if SelectedChecks.Count() = 1 then begin
             SelectedChecks.Reset();
             SelectedChecks.SetPosition(SelectionPosition);
             SelectedChecks.SetRecFilter();

--- a/SBIDataBraider_APP/src/SupportWizard/UI/SPBSupportWizardList.Page.al
+++ b/SBIDataBraider_APP/src/SupportWizard/UI/SPBSupportWizardList.Page.al
@@ -12,7 +12,7 @@ page 71033620 "SPB Support Wizard List"
 
     layout
     {
-        area(content)
+        area(Content)
         {
             repeater(General)
             {
@@ -132,7 +132,7 @@ page 71033620 "SPB Support Wizard List"
                     Rec.Modify(true);
                 end;
             until Rec.Next() < 1;
-        If Rec.FindFirst() then;
+        if Rec.FindFirst() then;
         CurrPage.Update(false);
     end;
 }

--- a/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
+++ b/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
@@ -238,7 +238,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         end;
     end;
 
-    procedure GetEndpointTelemetryDataJson(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header") DataJson: Text;
+    procedure GetEndpointTelemetryDataJson(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header") DataJson: Text
     var
         SPBDBraiderConfigLine: Record "SPB DBraider Config. Line";
         DataStructureJsonArray: JsonArray;
@@ -341,7 +341,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         end;
     end;
 
-    procedure BuildFQSI(var BreadcrumpRecordRefArray: array[100] of RecordRef; ToDepth: Integer) FQSI: Text;
+    procedure BuildFQSI(var BreadcrumpRecordRefArray: array[100] of RecordRef; ToDepth: Integer) FQSI: Text
     var
         i: Integer;
         FQSITextBuilder: TextBuilder;
@@ -354,7 +354,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         FQSI := FQSITextBuilder.ToText();
     end;
 
-    procedure TrimFQSI(InputFQSI: Text) FQSI: Text;
+    procedure TrimFQSI(InputFQSI: Text) FQSI: Text
     var
         i: Integer;
         Parts: List of [Text];

--- a/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
+++ b/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
@@ -9,7 +9,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         DestinationFieldRef: FieldRef;
     begin
         DestinationFieldRef := DestinationRecordRef.Field(FieldNo);
-        if DestinationFieldRef.Type = FieldType::Option then begin
+        if DestinationFieldRef.Type() = FieldType::Option then begin
             Evaluate(DestinationFieldRef, NewValue);
             DestinationFieldRef.Validate();
         end else
@@ -21,7 +21,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         DestinationFieldRef: FieldRef;
     begin
         DestinationFieldRef := DestinationRecordRef.Field(FieldNo);
-        if not (DestinationFieldRef.Type in
+        if not (DestinationFieldRef.Type() in
             [FieldType::Code, FieldType::Text])
         then begin
             Evaluate(DestinationFieldRef, NewValue);
@@ -49,9 +49,9 @@ codeunit 71033608 "SPB DBraider Utilities"
 
     begin
         DestinationFieldRef := DestinationRecordRef.Field(FieldNo);
-        case DestinationFieldRef.Type of
+        case DestinationFieldRef.Type() of
             FieldType::Code, FieldType::Text:
-                exit(StrLen(NewValue) <= DestinationFieldRef.Length);
+                exit(StrLen(NewValue) <= DestinationFieldRef.Length());
             FieldType::Integer:
                 exit(Evaluate(int, NewValue));
             FieldType::Decimal:
@@ -77,12 +77,11 @@ codeunit 71033608 "SPB DBraider Utilities"
         TargetKeyRef: KeyRef;
     begin
         TargetKeyRef := TargetTableRecordRef.KeyIndex(1);  // Primary Key
-        for i := 1 to TargetKeyRef.FieldCount do begin
+        for i := 1 to TargetKeyRef.FieldCount() do begin
             TargetFieldRef := TargetKeyRef.FieldIndex(i);
             if FieldNamesList = '' then
-                FieldNamesList := TargetFieldRef.Name
-            else
-                FieldNamesList := FieldNamesList + ', ' + TargetFieldRef.Name;
+                FieldNamesList := TargetFieldRef.Name() else
+                FieldNamesList := FieldNamesList + ', ' + TargetFieldRef.Name();
         end;
     end;
 
@@ -93,9 +92,9 @@ codeunit 71033608 "SPB DBraider Utilities"
         TargetKeyRef: KeyRef;
     begin
         TargetKeyRef := TargetTableRecordRef.KeyIndex(1);  // Primary Key
-        for i := 1 to TargetKeyRef.FieldCount do begin
+        for i := 1 to TargetKeyRef.FieldCount() do begin
             TargetFieldRef := TargetKeyRef.FieldIndex(i);
-            FieldNumbers.Add(TargetFieldRef.Number);
+            FieldNumbers.Add(TargetFieldRef.Number());
         end;
     end;
 
@@ -123,7 +122,7 @@ codeunit 71033608 "SPB DBraider Utilities"
             end;
         end;
 
-        if Fields.Count = 0 then
+        if Fields.Count() = 0 then
             // Suuuuuper ugly, hard-coding some of these because we have little choice
             case ParentTableNo of
                 36:  // Sales Header
@@ -204,7 +203,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         // Gather current month figures first
         if SPBDBraiderConfigHeader.FindSet(false) then
             repeat
-                SPBDBraiderConfigHeader.SetRange("Date Filter", CalcDate('<-CM>', Today), CalcDate('<CM>', Today));
+                SPBDBraiderConfigHeader.SetRange("Date Filter", CalcDate('<-CM>', Today()), CalcDate('<CM>', Today()));
                 SPBDBraiderConfigHeader.CalcFields(Usage, "Rows Read", "Rows Written");
                 ReadsTally += SPBDBraiderConfigHeader."Rows Read";
                 WritesTally += SPBDBraiderConfigHeader."Rows Written";
@@ -212,8 +211,8 @@ codeunit 71033608 "SPB DBraider Utilities"
         Results.Set('TotalReadsCM', ReadsTally);
         Results.Set('TotalWritesCM', WritesTally);
         if not SPBDBraiderConfigHeader.IsEmpty() then begin
-            Results.Set('AvgReadsCM', Round(ReadsTally / SPBDBraiderConfigHeader.Count, 0.01));
-            Results.Set('AvgWritesCM', Round(WritesTally / SPBDBraiderConfigHeader.Count, 0.01));
+            Results.Set('AvgReadsCM', Round(ReadsTally / SPBDBraiderConfigHeader.Count(), 0.01));
+            Results.Set('AvgWritesCM', Round(WritesTally / SPBDBraiderConfigHeader.Count(), 0.01));
         end else begin
             Results.Set('AvgReadsCM', 0);
             Results.Set('AvgWritesCM', 0);
@@ -230,8 +229,8 @@ codeunit 71033608 "SPB DBraider Utilities"
         Results.Set('TotalReadsAlltime', ReadsTally);
         Results.Set('TotalWritesAlltime', WritesTally);
         if not SPBDBraiderConfigHeader.IsEmpty() then begin
-            Results.Set('AvgReadsAlltime', Round(ReadsTally / SPBDBraiderConfigHeader.Count, 0.01));
-            Results.Set('AvgWritesAlltime', Round(WritesTally / SPBDBraiderConfigHeader.Count, 0.01));
+            Results.Set('AvgReadsAlltime', Round(ReadsTally / SPBDBraiderConfigHeader.Count(), 0.01));
+            Results.Set('AvgWritesAlltime', Round(WritesTally / SPBDBraiderConfigHeader.Count(), 0.01));
         end else begin
             Results.Set('AvgReadsAlltime', 0);
             Results.Set('AvgWritesAlltime', 0);
@@ -349,7 +348,7 @@ codeunit 71033608 "SPB DBraider Utilities"
         for i := 1 to ToDepth do begin
             if i > 1 then
                 FQSITextBuilder.Append('.');
-            FQSITextBuilder.Append(Format(BreadcrumpRecordRefArray[i].Field(BreadcrumpRecordRefArray[i].SystemIdNo).Value));
+            FQSITextBuilder.Append(Format(BreadcrumpRecordRefArray[i].Field(BreadcrumpRecordRefArray[i].SystemIdNo()).Value()));
         end;
         FQSI := FQSITextBuilder.ToText();
     end;
@@ -366,9 +365,9 @@ codeunit 71033608 "SPB DBraider Utilities"
         if InputFQSI = '' then
             exit;
         Parts := InputFQSI.Split('.');
-        if Parts.Count < 2 then
+        if Parts.Count() < 2 then
             exit(InputFQSI);
-        for i := 1 to Parts.Count - 1 do begin
+        for i := 1 to Parts.Count() - 1 do begin
             if i > 1 then
                 FQSITextBuilder.Append('.');
             Parts.Get(i, ThisPart);

--- a/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
+++ b/SBIDataBraider_APP/src/Utilities/SPBDBraiderUtilities.Codeunit.al
@@ -122,7 +122,7 @@ codeunit 71033608 "SPB DBraider Utilities"
             end;
         end;
 
-        if Fields.Count() = 0 then
+        if Fields.IsEmpty() then
             // Suuuuuper ugly, hard-coding some of these because we have little choice
             case ParentTableNo of
                 36:  // Sales Header


### PR DESCRIPTION
A remark on the [NotBlank should be set explicitly for tables with a single-field primary key](https://github.com/Spare-Brained-Community/SBI-DataBraider/commit/2039c3d8c142260a2de3a68786458aab0c88a083); This could be considered as a breaking change, where we previously allowed to have a Config Header with a blank code. As there are multiple table relations to this table, I believe it's justified to change this behavior.