### PR TITLE
Feature #23 - Add Swagger/OpenAPI 3.0 export

### DIFF
--- a/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderManager.PermissionSet.al
+++ b/SBIDataBraider_APP/src/.permissionsets/SPBDBraiderManager.PermissionSet.al
@@ -45,6 +45,7 @@ permissionset 71033600 "SPB DBraider Manager"
         codeunit "SPB DBraider Events" = X,
         codeunit "SPB DBraider Gen PowerBI" = X,
         codeunit "SPB DBraider Gen. Postman" = X,
+        codeunit "SPB DBraider Gen. Swagger" = X,
         codeunit "SPB DBraider Input Processor" = X,
         codeunit "SPB DBraider Input Validator" = X,
         codeunit "SPB DBraider JSON Templ. Maker" = X,

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
@@ -111,6 +111,41 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         Result.Add(SecurityObj);
     end;
 
+    local procedure ReadResponse200(SchemaName: Text) Result: JsonObject
+    var
+        CodeSchemaObj: JsonObject;
+        ContentObj: JsonObject;
+        DescSchemaObj: JsonObject;
+        IncludedCountSchemaObj: JsonObject;
+        JsonResponseObj: JsonObject;
+        JsonResultItemsObj: JsonObject;
+        JsonResultSchemaObj: JsonObject;
+        MediaTypeObj: JsonObject;
+        ResponsePropertiesObj: JsonObject;
+        ResponseSchemaObj: JsonObject;
+        TopLevelCountSchemaObj: JsonObject;
+    begin
+        CodeSchemaObj.Add('type', 'string');
+        DescSchemaObj.Add('type', 'string');
+        JsonResultItemsObj.Add('$ref', '#/components/schemas/' + SchemaName);
+        JsonResultSchemaObj.Add('type', 'array');
+        JsonResultSchemaObj.Add('items', JsonResultItemsObj);
+        TopLevelCountSchemaObj.Add('type', 'integer');
+        IncludedCountSchemaObj.Add('type', 'integer');
+        ResponsePropertiesObj.Add('code', CodeSchemaObj);
+        ResponsePropertiesObj.Add('description', DescSchemaObj);
+        ResponsePropertiesObj.Add('jsonResult', JsonResultSchemaObj);
+        ResponsePropertiesObj.Add('topLevelRecordCount', TopLevelCountSchemaObj);
+        ResponsePropertiesObj.Add('includedRecordCount', IncludedCountSchemaObj);
+        ResponseSchemaObj.Add('type', 'object');
+        ResponseSchemaObj.Add('properties', ResponsePropertiesObj);
+        MediaTypeObj.Add('schema', ResponseSchemaObj);
+        ContentObj.Add('application/json', MediaTypeObj);
+        JsonResponseObj.Add('description', 'Successful response');
+        JsonResponseObj.Add('content', ContentObj);
+        Result.Add('200', JsonResponseObj);
+    end;
+
     local procedure StringResponse200() Result: JsonObject
     var
         ContentObj: JsonObject;
@@ -135,7 +170,7 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         // Determine the type of Endpoint we are dealing with
         case SPBDBraiderConfigHeader."Endpoint Type" of
             Enum::"SPB DBraider Endpoint Type"::"Read Only":
-                AddReadOnlyPaths(SPBDBraiderConfigHeader, PathsObj);
+                AddReadOnlyPaths(SPBDBraiderConfigHeader, PathsObj, SchemasObj);
             //INFO: Delta Read is not yet implemented
             // Enum::"SPB DBraider Endpoint Type"::"Delta Read":
             //     AddDeltaReadPaths(SPBDBraiderConfigHeader, PathsObj, SchemasObj);
@@ -150,8 +185,9 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         end;
     end;
 
-    local procedure AddReadOnlyPaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject)
+    local procedure AddReadOnlyPaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject; var SchemasObj: JsonObject)
     var
+        SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field";
         GetOperationObj: JsonObject;
         GetPathObj: JsonObject;
         PostOperationObj: JsonObject;
@@ -163,15 +199,24 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         RequestBodySchemaPropsObj: JsonObject;
         CodePropObj: JsonObject;
         FilterJsonPropObj: JsonObject;
+        SchemaName: Text;
     begin
-        // GET /read('{code}') — summary from Config Header Description, response 200 with jsonResult string
+        SchemaName := SPBDBraiderConfigHeader."Code" + 'ReadItem';
+
+        // Build the response schema for included fields and add it to components/schemas
+        SPBDBraiderConfLineFields.SetRange("Config. Code", SPBDBraiderConfigHeader."Code");
+        SPBDBraiderConfLineFields.SetRange(Included, true);
+        SPBDBraiderConfLineFields.SetAutoCalcFields("Table Name", "Field Name");
+        SchemasObj.Add(SchemaName, BuildFieldSchema(SPBDBraiderConfLineFields));
+
+        // GET /read('{code}') — summary from Config Header Description, response 200 with schema
         GetOperationObj.Add('summary', SPBDBraiderConfigHeader.Description);
         GetOperationObj.Add('security', SecurityRequirement());
-        GetOperationObj.Add('responses', StringResponse200());
+        GetOperationObj.Add('responses', ReadResponse200(SchemaName));
         GetPathObj.Add('get', GetOperationObj);
         PathsObj.Add('/read(''' + SPBDBraiderConfigHeader."Code" + ''')', GetPathObj);
 
-        // POST /read — body: { code, filterJson }, response 200
+        // POST /read — body: { code, filterJson }, response 200 with schema
         CodePropObj.Add('type', 'string');
         FilterJsonPropObj.Add('type', 'string');
         RequestBodySchemaPropsObj.Add('code', CodePropObj);
@@ -185,7 +230,7 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         PostOperationObj.Add('summary', SPBDBraiderConfigHeader.Description + ' (Filtered)');
         PostOperationObj.Add('security', SecurityRequirement());
         PostOperationObj.Add('requestBody', RequestBodyObj);
-        PostOperationObj.Add('responses', StringResponse200());
+        PostOperationObj.Add('responses', ReadResponse200(SchemaName));
         PostPathObj.Add('post', PostOperationObj);
         PathsObj.Add('/read/' + SPBDBraiderConfigHeader."Code", PostPathObj);
     end;
@@ -213,7 +258,7 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         SPBDBraiderConfLineFields.SetRange("Config. Code", SPBDBraiderConfigHeader."Code");
         SPBDBraiderConfLineFields.SetRange("Write Enabled", true);
         SPBDBraiderConfLineFields.SetAutoCalcFields("Table Name", "Field Name");
-        SchemasObj.Add(SchemaName, BuildWriteSchema(SPBDBraiderConfLineFields));
+        SchemasObj.Add(SchemaName, BuildFieldSchema(SPBDBraiderConfLineFields));
 
         // POST /write — body schema by reference
         SchemaRefObj.Add('$ref', '#/components/schemas/' + SchemaName);
@@ -229,7 +274,7 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         PathsObj.Add('/write/' + SPBDBraiderConfigHeader."Code", PostPathObj);
     end;
 
-    local procedure BuildWriteSchema(var SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field") Result: JsonObject
+    local procedure BuildFieldSchema(var SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field") Result: JsonObject
     var
         SPBDBraiderJsonUtilities: Codeunit "SPB DBraider JSON Utilities";
         PropertiesObj: JsonObject;

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
@@ -277,8 +277,10 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
     local procedure BuildFieldSchema(var SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field") Result: JsonObject
     var
         SPBDBraiderJsonUtilities: Codeunit "SPB DBraider JSON Utilities";
-        PropertiesObj: JsonObject;
         FieldSchemaObj: JsonObject;
+        PropertiesObj: JsonObject;
+        RequiredArr: JsonArray;
+        PropertyName: Text;
     begin
         Result.Add('type', 'object');
         if SPBDBraiderConfLineFields.FindSet() then
@@ -292,12 +294,19 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
                     else
                         FieldSchemaObj.Add('type', 'string');
                 end;
-                PropertiesObj.Add(
-                    SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Table Name") + '.' +
-                    SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Field Name"),
-                    FieldSchemaObj);
+                // Use Manual Field Caption when set (it is already JSON-safe), otherwise use the field name
+                PropertyName := SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Table Name") + '.';
+                if SPBDBraiderConfLineFields."Manual Field Caption" <> '' then
+                    PropertyName += SPBDBraiderConfLineFields."Manual Field Caption"
+                else
+                    PropertyName += SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Field Name");
+                PropertiesObj.Add(PropertyName, FieldSchemaObj);
+                if SPBDBraiderConfLineFields.Mandatory then
+                    RequiredArr.Add(PropertyName);
             until SPBDBraiderConfLineFields.Next() < 1;
         Result.Add('properties', PropertiesObj);
+        if RequiredArr.Count() > 0 then
+            Result.Add('required', RequiredArr);
     end;
     #endregion BraiderParts
 }

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
@@ -27,8 +27,8 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         // info object
         OpenApiJson.Add('info', InfoObject());
 
-        // servers array with placeholder URI
-        ServerObj.Add('url', '{baseuri}/api/sparebrained/databraider/v2.0/companies({companyid})');
+        // servers array - use the real BC SaaS cloud URI
+        ServerObj.Add('url', GetServerUrl());
         ServersArr.Add(ServerObj);
         OpenApiJson.Add('servers', ServersArr);
 
@@ -59,16 +59,41 @@ codeunit 71033622 "SPB DBraider Gen. Swagger"
         Result.Add('version', '2.0');
     end;
 
+    local procedure GetServerUrl(): Text
+    var
+        AzureADTenant: Codeunit "Azure AD Tenant";
+        EnvironmentInformation: Codeunit "Environment Information";
+        Company: Record Company;
+        CompanyId: Text;
+    begin
+        Company.Get(CompanyName());
+        // Format GUID as lowercase without braces for use in BC API URLs
+        CompanyId := LowerCase(DelChr(Format(Company.SystemId, 0, 4), '=', '{}'));
+        exit(StrSubstNo(
+            'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/sparebrained/databraider/v2.0/companies(%3)',
+            AzureADTenant.GetAadTenantId(),
+            EnvironmentInformation.GetEnvironmentName(),
+            CompanyId));
+    end;
+
+    local procedure GetTokenUrl(): Text
+    var
+        AzureADTenant: Codeunit "Azure AD Tenant";
+    begin
+        exit(StrSubstNo(
+            'https://login.microsoftonline.com/%1/oauth2/v2.0/token',
+            AzureADTenant.GetAadTenantId()));
+    end;
+
     local procedure SecuritySchemes() Result: JsonObject
     var
         ClientCredentialsObj: JsonObject;
-        FlowObj: JsonObject;
         FlowsObj: JsonObject;
         OAuth2Obj: JsonObject;
         ScopesObj: JsonObject;
     begin
         ScopesObj.Add('https://api.businesscentral.dynamics.com/.default', 'Business Central API access');
-        ClientCredentialsObj.Add('tokenUrl', 'https://login.microsoftonline.com/{tenantid}/oauth2/v2.0/token');
+        ClientCredentialsObj.Add('tokenUrl', GetTokenUrl());
         ClientCredentialsObj.Add('scopes', ScopesObj);
         FlowsObj.Add('clientCredentials', ClientCredentialsObj);
         OAuth2Obj.Add('type', 'oauth2');

--- a/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
+++ b/SBIDataBraider_APP/src/Configuration/Accelerators/SPBDBraiderGenSwagger.Codeunit.al
@@ -1,0 +1,233 @@
+codeunit 71033622 "SPB DBraider Gen. Swagger"
+{
+    Access = Internal;
+    TableNo = "SPB DBraider Config. Header";
+
+    var
+        SPBDBraiderEvents: Codeunit "SPB DBraider Events";
+
+    trigger OnRun()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        InS: InStream;
+        ComponentsObj: JsonObject;
+        OpenApiJson: JsonObject;
+        OutS: OutStream;
+        PathsObj: JsonObject;
+        SchemasObj: JsonObject;
+        ServersArr: JsonArray;
+        ServerObj: JsonObject;
+        Filename: Text;
+    begin
+        // Build the OpenAPI 3.0 root object
+
+        // openapi version
+        OpenApiJson.Add('openapi', '3.0.0');
+
+        // info object
+        OpenApiJson.Add('info', InfoObject());
+
+        // servers array with placeholder URI
+        ServerObj.Add('url', '{baseuri}/api/sparebrained/databraider/v2.0/companies({companyid})');
+        ServersArr.Add(ServerObj);
+        OpenApiJson.Add('servers', ServersArr);
+
+        // paths object - loop through Config Headers
+        if Rec.FindSet() then
+            repeat
+                AddConfigHeaderPaths(Rec, PathsObj, SchemasObj);
+            until Rec.Next() < 1;
+        OpenApiJson.Add('paths', PathsObj);
+
+        // components object - securitySchemes + schemas
+        ComponentsObj.Add('securitySchemes', SecuritySchemes());
+        ComponentsObj.Add('schemas', SchemasObj);
+        OpenApiJson.Add('components', ComponentsObj);
+
+        // Download the resulting JSON to a file
+        TempBlob.CreateOutStream(OutS, TextEncoding::UTF8);
+        OpenApiJson.WriteTo(OutS);
+        TempBlob.CreateInStream(InS);
+        Filename := 'BraiderSwagger.json';
+        DownloadFromStream(InS, 'Save Swagger File', '', 'JSON File (*.json)|*.json', Filename);
+    end;
+
+    #region SwaggerEssentials
+    local procedure InfoObject() Result: JsonObject
+    begin
+        Result.Add('title', 'Data Braider API');
+        Result.Add('version', '2.0');
+    end;
+
+    local procedure SecuritySchemes() Result: JsonObject
+    var
+        ClientCredentialsObj: JsonObject;
+        FlowObj: JsonObject;
+        FlowsObj: JsonObject;
+        OAuth2Obj: JsonObject;
+        ScopesObj: JsonObject;
+    begin
+        ScopesObj.Add('https://api.businesscentral.dynamics.com/.default', 'Business Central API access');
+        ClientCredentialsObj.Add('tokenUrl', 'https://login.microsoftonline.com/{tenantid}/oauth2/v2.0/token');
+        ClientCredentialsObj.Add('scopes', ScopesObj);
+        FlowsObj.Add('clientCredentials', ClientCredentialsObj);
+        OAuth2Obj.Add('type', 'oauth2');
+        OAuth2Obj.Add('flows', FlowsObj);
+        Result.Add('OAuth2', OAuth2Obj);
+    end;
+
+    local procedure SecurityRequirement() Result: JsonArray
+    var
+        SecurityObj: JsonObject;
+        ScopeArr: JsonArray;
+    begin
+        ScopeArr.Add('https://api.businesscentral.dynamics.com/.default');
+        SecurityObj.Add('OAuth2', ScopeArr);
+        Result.Add(SecurityObj);
+    end;
+
+    local procedure StringResponse200() Result: JsonObject
+    var
+        ContentObj: JsonObject;
+        JsonResultObj: JsonObject;
+        MediaTypeObj: JsonObject;
+        SchemaObj: JsonObject;
+    begin
+        SchemaObj.Add('type', 'string');
+        MediaTypeObj.Add('schema', SchemaObj);
+        ContentObj.Add('application/json', MediaTypeObj);
+        JsonResultObj.Add('description', 'Successful response');
+        JsonResultObj.Add('content', ContentObj);
+        Result.Add('200', JsonResultObj);
+    end;
+    #endregion SwaggerEssentials
+
+    #region BraiderParts
+    local procedure AddConfigHeaderPaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject; var SchemasObj: JsonObject)
+    var
+        isHandled: Boolean;
+    begin
+        // Determine the type of Endpoint we are dealing with
+        case SPBDBraiderConfigHeader."Endpoint Type" of
+            Enum::"SPB DBraider Endpoint Type"::"Read Only":
+                AddReadOnlyPaths(SPBDBraiderConfigHeader, PathsObj);
+            //INFO: Delta Read is not yet implemented
+            // Enum::"SPB DBraider Endpoint Type"::"Delta Read":
+            //     AddDeltaReadPaths(SPBDBraiderConfigHeader, PathsObj, SchemasObj);
+            Enum::"SPB DBraider Endpoint Type"::"Per Record":
+                AddWritePaths(SPBDBraiderConfigHeader, PathsObj, SchemasObj);
+            Enum::"SPB DBraider Endpoint Type"::Batch:
+                AddWritePaths(SPBDBraiderConfigHeader, PathsObj, SchemasObj);
+            else begin
+                isHandled := false;
+                SPBDBraiderEvents.OnUnhandledPostmanEndpointType(SPBDBraiderConfigHeader, isHandled);
+            end;
+        end;
+    end;
+
+    local procedure AddReadOnlyPaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject)
+    var
+        GetOperationObj: JsonObject;
+        GetPathObj: JsonObject;
+        PostOperationObj: JsonObject;
+        PostPathObj: JsonObject;
+        RequestBodyContentObj: JsonObject;
+        RequestBodyMediaTypeObj: JsonObject;
+        RequestBodyObj: JsonObject;
+        RequestBodySchemaObj: JsonObject;
+        RequestBodySchemaPropsObj: JsonObject;
+        CodePropObj: JsonObject;
+        FilterJsonPropObj: JsonObject;
+    begin
+        // GET /read('{code}') — summary from Config Header Description, response 200 with jsonResult string
+        GetOperationObj.Add('summary', SPBDBraiderConfigHeader.Description);
+        GetOperationObj.Add('security', SecurityRequirement());
+        GetOperationObj.Add('responses', StringResponse200());
+        GetPathObj.Add('get', GetOperationObj);
+        PathsObj.Add('/read(''' + SPBDBraiderConfigHeader."Code" + ''')', GetPathObj);
+
+        // POST /read — body: { code, filterJson }, response 200
+        CodePropObj.Add('type', 'string');
+        FilterJsonPropObj.Add('type', 'string');
+        RequestBodySchemaPropsObj.Add('code', CodePropObj);
+        RequestBodySchemaPropsObj.Add('filterJson', FilterJsonPropObj);
+        RequestBodySchemaObj.Add('type', 'object');
+        RequestBodySchemaObj.Add('properties', RequestBodySchemaPropsObj);
+        RequestBodyMediaTypeObj.Add('schema', RequestBodySchemaObj);
+        RequestBodyContentObj.Add('application/json', RequestBodyMediaTypeObj);
+        RequestBodyObj.Add('required', true);
+        RequestBodyObj.Add('content', RequestBodyContentObj);
+        PostOperationObj.Add('summary', SPBDBraiderConfigHeader.Description + ' (Filtered)');
+        PostOperationObj.Add('security', SecurityRequirement());
+        PostOperationObj.Add('requestBody', RequestBodyObj);
+        PostOperationObj.Add('responses', StringResponse200());
+        PostPathObj.Add('post', PostOperationObj);
+        PathsObj.Add('/read/' + SPBDBraiderConfigHeader."Code", PostPathObj);
+    end;
+
+    //INFO: This is a placeholder for the Delta Read endpoint, which is not yet implemented
+    // local procedure AddDeltaReadPaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject; var SchemasObj: JsonObject)
+    // begin
+
+    // end;
+
+    local procedure AddWritePaths(SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header"; var PathsObj: JsonObject; var SchemasObj: JsonObject)
+    var
+        SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field";
+        PostOperationObj: JsonObject;
+        PostPathObj: JsonObject;
+        RequestBodyContentObj: JsonObject;
+        RequestBodyMediaTypeObj: JsonObject;
+        RequestBodyObj: JsonObject;
+        SchemaRefObj: JsonObject;
+        SchemaName: Text;
+    begin
+        SchemaName := SPBDBraiderConfigHeader."Code" + 'WriteBody';
+
+        // Build the schema for this endpoint and add it to components/schemas
+        SPBDBraiderConfLineFields.SetRange("Config. Code", SPBDBraiderConfigHeader."Code");
+        SPBDBraiderConfLineFields.SetRange("Write Enabled", true);
+        SPBDBraiderConfLineFields.SetAutoCalcFields("Table Name", "Field Name");
+        SchemasObj.Add(SchemaName, BuildWriteSchema(SPBDBraiderConfLineFields));
+
+        // POST /write — body schema by reference
+        SchemaRefObj.Add('$ref', '#/components/schemas/' + SchemaName);
+        RequestBodyMediaTypeObj.Add('schema', SchemaRefObj);
+        RequestBodyContentObj.Add('application/json', RequestBodyMediaTypeObj);
+        RequestBodyObj.Add('required', true);
+        RequestBodyObj.Add('content', RequestBodyContentObj);
+        PostOperationObj.Add('summary', SPBDBraiderConfigHeader.Description);
+        PostOperationObj.Add('security', SecurityRequirement());
+        PostOperationObj.Add('requestBody', RequestBodyObj);
+        PostOperationObj.Add('responses', StringResponse200());
+        PostPathObj.Add('post', PostOperationObj);
+        PathsObj.Add('/write/' + SPBDBraiderConfigHeader."Code", PostPathObj);
+    end;
+
+    local procedure BuildWriteSchema(var SPBDBraiderConfLineFields: Record "SPB DBraider ConfLine Field") Result: JsonObject
+    var
+        SPBDBraiderJsonUtilities: Codeunit "SPB DBraider JSON Utilities";
+        PropertiesObj: JsonObject;
+        FieldSchemaObj: JsonObject;
+    begin
+        Result.Add('type', 'object');
+        if SPBDBraiderConfLineFields.FindSet() then
+            repeat
+                Clear(FieldSchemaObj);
+                case SPBDBraiderConfLineFields."Field Type" of
+                    "SPB DBraider Field Data Type"::Boolean:
+                        FieldSchemaObj.Add('type', 'boolean');
+                    "SPB DBraider Field Data Type"::Decimal, "SPB DBraider Field Data Type"::Integer:
+                        FieldSchemaObj.Add('type', 'number');
+                    else
+                        FieldSchemaObj.Add('type', 'string');
+                end;
+                PropertiesObj.Add(
+                    SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Table Name") + '.' +
+                    SPBDBraiderJsonUtilities.JsonSafeTableFieldName(SPBDBraiderConfLineFields."Field Name"),
+                    FieldSchemaObj);
+            until SPBDBraiderConfLineFields.Next() < 1;
+        Result.Add('properties', PropertiesObj);
+    end;
+    #endregion BraiderParts
+}

--- a/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigurations.Page.al
+++ b/SBIDataBraider_APP/src/Configuration/SPBDBraiderConfigurations.Page.al
@@ -153,6 +153,22 @@ page 71033601 "SPB DBraider Configurations"
                         SPBDBraiderGenPowerBI.Run(Rec);
                     end;
                 }
+                action(GenerateSwaggerAction)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Generate Swagger';
+                    Image = ExportFile;
+                    ToolTip = 'Generate a Swagger/OpenAPI 3.0 specification for the selected configurations.';
+
+                    trigger OnAction()
+                    var
+                        SPBDBraiderConfigHeader: Record "SPB DBraider Config. Header";
+                        SPBDBraiderGenSwagger: Codeunit "SPB DBraider Gen. Swagger";
+                    begin
+                        CurrPage.SetSelectionFilter(SPBDBraiderConfigHeader);
+                        SPBDBraiderGenSwagger.Run(SPBDBraiderConfigHeader);
+                    end;
+                }
                 action(GeneratePowerAutomateAction)
                 {
                     ApplicationArea = All;
@@ -238,6 +254,9 @@ page 71033601 "SPB DBraider Configurations"
                 {
                 }
                 actionref(GeneratePowerBIQueryAction_Promoted; GeneratePowerBIQueryAction)
+                {
+                }
+                actionref(GenerateSwaggerAction_Promoted; GenerateSwaggerAction)
                 {
                 }
                 actionref(GeneratePowerAutomateAction_Promoted; GeneratePowerAutomateAction)


### PR DESCRIPTION
Adds Swagger/OpenAPI 3.0 export generator alongside existing Postman and PowerBI generators.

## Changes
- New codeunit SPB DBraider Gen. Swagger (71033622)
- Generates OpenAPI 3.0 JSON for all enabled endpoints, fully driven by configuration data
- OAuth2 client credentials security scheme
- Generate Swagger action on Configurations page
- `SPB DBraider Gen. Swagger` added to Manager permissionset

## OpenAPI Structure
The generated OpenAPI 3.0 document includes:
- **Info**: Title "Data Braider API", version "2.0"
- **Servers**: Real BC SaaS/Cloud URL constructed at runtime from the current tenant ID, environment name, and company GUID:  
  `https://api.businesscentral.dynamics.com/v2.0/{tenantId}/{environmentName}/api/sparebrained/databraider/v2.0/companies({companyGuid})`
- **Paths**: 
  - Read Only: `GET /read('{code}')` and `POST /read` for filtered reads, with response schemas built from configured fields (`Included = true`)
  - Write: `POST /write` with request body schemas built from configured fields (`Write Enabled = true`)
- **Components**: 
  - SecuritySchemes with OAuth2 client credentials flow, including a real token URL (`https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token`) resolved at runtime
  - Schemas for both read response items (`{code}ReadItem`) and write request bodies (`{code}WriteBody`), dynamically generated from the Braider field configuration

## Field Type Mapping
- Boolean fields → `type: "boolean"`
- Decimal/Integer fields → `type: "number"`
- All other fields → `type: "string"`

## Runtime URL Resolution
Unlike the Postman generator (which uses `{{baseUri}}` placeholder variables for on-prem/cloud flexibility), the Swagger generator targets SaaS/Cloud exclusively and resolves the full API URL at generation time using:
- `Codeunit "Azure AD Tenant".GetAadTenantId()` — AAD tenant ID
- `Codeunit "Environment Information".GetEnvironmentName()` — environment name
- `Company.SystemId` — current company GUID

## Configuration-Driven Schema Generation
Both read and write paths derive their schemas directly from `SPB DBraider ConfLine Field` records:
- **Read endpoints**: response schema (`{code}ReadItem`) built from fields where `Included = true`, wrapped in the standard BC API response envelope (`code`, `description`, `jsonResult` array, `topLevelRecordCount`, `includedRecordCount`)
- **Write endpoints**: request body schema (`{code}WriteBody`) built from fields where `Write Enabled = true`

### Field Naming
Property names in all schemas respect the **Manual Field Caption** setting: when a field has a `Manual Field Caption` configured, that value is used as the JSON property name suffix (matching actual API output). When not set, the standard JSON-safe field name is used.

### Mandatory Fields
Fields with `Mandatory = true` are listed in an OpenAPI 3.0 `required` array on the schema object, allowing OpenAPI-compatible tooling to clearly indicate which fields must be provided.

## Testing
The action can be tested by:
1. Opening the Data Braider Configurations page
2. Selecting one or more configurations
3. Clicking "Generate Swagger" action
4. The BraiderSwagger.json file will be downloaded
5. Import the JSON into any OpenAPI-compatible tool (Swagger UI, Postman, Azure API Management, etc.)

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.