### PR TITLE
#26 Export / Import Configurations

### DIFF
--- a/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderExport.XmlPort.al
+++ b/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderExport.XmlPort.al
@@ -24,6 +24,9 @@ xmlport 71033601 "SPB DBraider Export"
                 fieldelement(EndpointType; SPBDBraiderConfigHeader."Endpoint Type")
                 {
                 }
+                fieldelement(Enabled; SPBDBraiderConfigHeader.Enabled)
+                {
+                }
                 fieldelement(RequirePK; SPBDBraiderConfigHeader."Require PK")
                 {
                 }
@@ -36,7 +39,55 @@ xmlport 71033601 "SPB DBraider Export"
                 fieldelement(DeleteAllowed; SPBDBraiderConfigHeader."Delete Allowed")
                 {
                 }
+                fieldelement(PreventReading; SPBDBraiderConfigHeader."Prevent Reading")
+                {
+                }
+                fieldelement(DisableAutoModifiedAt; SPBDBraiderConfigHeader."Disable Auto ModifiedAt")
+                {
+                }
+                fieldelement(DisableAutoSystemId; SPBDBraiderConfigHeader."Disable Auto SystemId")
+                {
+                }
+                fieldelement(HideFromLists; SPBDBraiderConfigHeader."Hide from Lists")
+                {
+                }
+                fieldelement(DisableRelatedId; SPBDBraiderConfigHeader."Disable Related Id")
+                {
+                }
+                fieldelement(EmitRawDiagnosticData; SPBDBraiderConfigHeader."Emit Raw Diagnostic Data")
+                {
+                }
                 fieldelement(OutputJSONType; SPBDBraiderConfigHeader."Output JSON Type")
+                {
+                }
+                fieldelement(LoggingEnabled; SPBDBraiderConfigHeader."Logging Enabled")
+                {
+                }
+                fieldelement(ClearLogsCount; SPBDBraiderConfigHeader."Clear Logs Count")
+                {
+                }
+                fieldelement(ClearOlderThan; SPBDBraiderConfigHeader."Clear Older Than")
+                {
+                }
+                fieldelement(PageSize; SPBDBraiderConfigHeader."Page Size")
+                {
+                }
+                fieldelement(EmitTelemetryReadBefore; SPBDBraiderConfigHeader."Emit Telemetry Read Before")
+                {
+                }
+                fieldelement(EmitTelemetryReadAfter; SPBDBraiderConfigHeader."Emit Telemetry Read After")
+                {
+                }
+                fieldelement(EmitTelemetryWriteBefore; SPBDBraiderConfigHeader."Emit Telemetry Write Before")
+                {
+                }
+                fieldelement(EmitTelemetryWriteAfter; SPBDBraiderConfigHeader."Emit Telemetry Write After")
+                {
+                }
+                fieldelement(EmitTelemetryIncludeBody; SPBDBraiderConfigHeader."Emit Telemetry Include Body")
+                {
+                }
+                fieldelement(DataArchiveVersions; SPBDBraiderConfigHeader."Data Archive Versions")
                 {
                 }
 
@@ -44,6 +95,7 @@ xmlport 71033601 "SPB DBraider Export"
                 {
                     LinkFields = "Config. Code" = field("Code");
                     LinkTable = SPBDBraiderConfigHeader;
+                    MinOccurs = Zero;
                     SourceTableView = sorting("Config. Code", "Line No.") order(ascending);
                     fieldelement(ConfigCode; SPBDBraiderConfigLine."Config. Code")
                     {
@@ -78,6 +130,7 @@ xmlport 71033601 "SPB DBraider Export"
                 {
                     LinkFields = "Config. Code" = field("Code");
                     LinkTable = SPBDBraiderConfigHeader;
+                    MinOccurs = Zero;
                     SourceTableView = sorting("Config. Code", "Config. Line No.", "Field No.") order(ascending);
                     fieldelement(ConfigCode; SPBDBraiderConfLineField."Config. Code")
                     {
@@ -106,10 +159,31 @@ xmlport 71033601 "SPB DBraider Export"
                     fieldelement(Mandatory; SPBDBraiderConfLineField.Mandatory)
                     {
                     }
+                    fieldelement(UpsertMatch; SPBDBraiderConfLineField."Upsert Match")
+                    {
+                    }
+                    fieldelement(DisableValidation; SPBDBraiderConfLineField."Disable Validation")
+                    {
+                    }
+                    fieldelement(DisableAutoSplitKey; SPBDBraiderConfLineField."Disable Auto-Split Key")
+                    {
+                    }
+                    fieldelement(ModificationReValidate; SPBDBraiderConfLineField."Modification Re-Validate")
+                    {
+                    }
+                    fieldelement(DisableRelatedId; SPBDBraiderConfLineField."Disable Related Id")
+                    {
+                    }
+                    fieldelement(DateTimeTimezone; SPBDBraiderConfLineField."DateTime Timezone")
+                    {
+                    }
                     fieldelement(TableNo; SPBDBraiderConfLineField."Table No.")
                     {
                     }
                     fieldelement(PrimaryKey; SPBDBraiderConfLineField."Primary Key")
+                    {
+                    }
+                    fieldelement(ManualFieldCaption; SPBDBraiderConfLineField."Manual Field Caption")
                     {
                     }
                 }

--- a/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderExport.XmlPort.al
+++ b/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderExport.XmlPort.al
@@ -117,6 +117,7 @@ xmlport 71033601 "SPB DBraider Export"
                 {
                     LinkFields = "Config. Code" = field("Code");
                     LinkTable = SPBDBraiderConfigHeader;
+                    MinOccurs = Zero;
                     SourceTableView = sorting("Config. Code", "Config. Line No.", "FlowField Line No.") order(ascending);
 
                     fieldelement(ConfigCode; SPBDBraiderConfLineFlow."Config. Code")
@@ -146,6 +147,7 @@ xmlport 71033601 "SPB DBraider Export"
                 {
                     LinkFields = "Config. Code" = field("Code");
                     LinkTable = SPBDBraiderConfigHeader;
+                    MinOccurs = Zero;
                     SourceTableView = sorting("Config. Code", "Config. Line No.", "Relation Line No.") order(ascending);
                     fieldelement(ConfigCode; SPBDBraiderConfLineRelation."Config. Code")
                     {

--- a/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderImport.XmlPort.al
+++ b/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderImport.XmlPort.al
@@ -24,6 +24,10 @@ xmlport 71033600 "SPB DBraider Import"
                 }
                 fieldelement(EndpointType; SPBDBraiderConfigHeader."Endpoint Type")
                 {
+                    FieldValidate = No;
+                }
+                fieldelement(Enabled; SPBDBraiderConfigHeader.Enabled)
+                {
                 }
                 fieldelement(RequirePK; SPBDBraiderConfigHeader."Require PK")
                 {
@@ -37,7 +41,56 @@ xmlport 71033600 "SPB DBraider Import"
                 fieldelement(DeleteAllowed; SPBDBraiderConfigHeader."Delete Allowed")
                 {
                 }
+                fieldelement(PreventReading; SPBDBraiderConfigHeader."Prevent Reading")
+                {
+                }
+                fieldelement(DisableAutoModifiedAt; SPBDBraiderConfigHeader."Disable Auto ModifiedAt")
+                {
+                }
+                fieldelement(DisableAutoSystemId; SPBDBraiderConfigHeader."Disable Auto SystemId")
+                {
+                }
+                fieldelement(HideFromLists; SPBDBraiderConfigHeader."Hide from Lists")
+                {
+                }
+                fieldelement(DisableRelatedId; SPBDBraiderConfigHeader."Disable Related Id")
+                {
+                }
+                fieldelement(EmitRawDiagnosticData; SPBDBraiderConfigHeader."Emit Raw Diagnostic Data")
+                {
+                }
                 fieldelement(OutputJSONType; SPBDBraiderConfigHeader."Output JSON Type")
+                {
+                }
+                fieldelement(LoggingEnabled; SPBDBraiderConfigHeader."Logging Enabled")
+                {
+                }
+                fieldelement(ClearLogsCount; SPBDBraiderConfigHeader."Clear Logs Count")
+                {
+                }
+                fieldelement(ClearOlderThan; SPBDBraiderConfigHeader."Clear Older Than")
+                {
+                }
+                fieldelement(PageSize; SPBDBraiderConfigHeader."Page Size")
+                {
+                }
+                fieldelement(EmitTelemetryReadBefore; SPBDBraiderConfigHeader."Emit Telemetry Read Before")
+                {
+                }
+                fieldelement(EmitTelemetryReadAfter; SPBDBraiderConfigHeader."Emit Telemetry Read After")
+                {
+                }
+                fieldelement(EmitTelemetryWriteBefore; SPBDBraiderConfigHeader."Emit Telemetry Write Before")
+                {
+                }
+                fieldelement(EmitTelemetryWriteAfter; SPBDBraiderConfigHeader."Emit Telemetry Write After")
+                {
+                }
+                fieldelement(EmitTelemetryIncludeBody; SPBDBraiderConfigHeader."Emit Telemetry Include Body")
+                {
+                    FieldValidate = No;
+                }
+                fieldelement(DataArchiveVersions; SPBDBraiderConfigHeader."Data Archive Versions")
                 {
                 }
 
@@ -113,11 +166,36 @@ xmlport 71033600 "SPB DBraider Import"
                     fieldelement(Mandatory; SPBDBraiderConfLineField.Mandatory)
                     {
                     }
+                    fieldelement(UpsertMatch; SPBDBraiderConfLineField."Upsert Match")
+                    {
+                    }
+                    fieldelement(DisableValidation; SPBDBraiderConfLineField."Disable Validation")
+                    {
+                        // The table OnValidate can raise a confirmation prompt for DisableAll. 
+                        // Without that, a valid exported configuration would not reliably round-trip through unattended import.
+                        FieldValidate = No;
+                    }
+                    fieldelement(DisableAutoSplitKey; SPBDBraiderConfLineField."Disable Auto-Split Key")
+                    {
+                    }
+                    fieldelement(ModificationReValidate; SPBDBraiderConfLineField."Modification Re-Validate")
+                    {
+                    }
+                    fieldelement(DisableRelatedId; SPBDBraiderConfLineField."Disable Related Id")
+                    {
+                    }
+                    fieldelement(DateTimeTimezone; SPBDBraiderConfLineField."DateTime Timezone")
+                    {
+                    }
                     fieldelement(TableNo; SPBDBraiderConfLineField."Table No.")
                     {
                     }
                     fieldelement(PrimaryKey; SPBDBraiderConfLineField."Primary Key")
                     {
+                    }
+                    fieldelement(ManualFieldCaption; SPBDBraiderConfLineField."Manual Field Caption")
+                    {
+                        FieldValidate = No;
                     }
 
                     trigger OnBeforeInsertRecord()
@@ -144,6 +222,7 @@ xmlport 71033600 "SPB DBraider Import"
                     }
                     fieldelement(ConfigLineNo; SPBDBraiderConfLineFlow."Config. Line No.")
                     {
+                        fieldvalidate = No;
                     }
                     fieldelement(FlowFieldLineNo; SPBDBraiderConfLineFlow."FlowField Line No.")
                     {
@@ -174,6 +253,7 @@ xmlport 71033600 "SPB DBraider Import"
                     }
                     fieldelement(ConfigLineNo; SPBDBraiderConfLineRelation."Config. Line No.")
                     {
+                        fieldvalidate = No;
                     }
                     fieldelement(RelationLineNo; SPBDBraiderConfLineRelation."Relation Line No.")
                     {
@@ -205,7 +285,7 @@ xmlport 71033600 "SPB DBraider Import"
             {
                 group(GroupName)
                 {
-                    InstructionalText = 'This step allows you to import or export Data Braider Configurations.';
+                    InstructionalText = 'This step allows you to import Data Braider Configurations.';
                     ShowCaption = false;
                 }
             }

--- a/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderImport.XmlPort.al
+++ b/SBIDataBraider_APP/src/Configuration/ImportExport/SPBDBraiderImport.XmlPort.al
@@ -124,6 +124,11 @@ xmlport 71033600 "SPB DBraider Import"
                     begin
                         SPBDBraiderConfLineField.Validate("Field No.");
                     end;
+
+                    trigger OnBeforeModifyRecord()
+                    begin
+                        SPBDBraiderConfLineField.Validate("Field No.");
+                    end;
                 }
 
                 tableelement(SPBDBraiderConfLineFlow; "SPB DBraider ConfLine Flow")

--- a/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
+++ b/SBIDataBraider_APP/src/Configuration/Lines/SPBDBraiderConfLineField.Table.al
@@ -262,6 +262,8 @@ table 71033603 "SPB DBraider ConfLine Field"
             FieldsRef := RecRef.Field(FieldNo);
             Rec."Field Type" := SPBDBraiderUtilities.MapFieldTypeToSPBFieldDataType(FieldsRef.Type());
             Rec."Field Class" := Format(FieldsRef.Class());
+            Rec."Fixed Field Caption" := FieldsRef.Caption();
+            Rec."Fixed Field Name" := FieldsRef.Name();
         end;
     end;
 


### PR DESCRIPTION
This is for #26 [Bug] Export / Import Configurations

Copilot Suggested that we make the following adjustments to the Export XMLPort:
SPBDBraiderConfLineFlow and SPBDBraiderConfLineRelation set MinOccurs = 0.

This seemed to fix the issue with the blank lines.

The problem was then when I was importing the file, none of the Field Names (Fixed Field Name) or Captions were populating.

With AutoReplace = true on the xmlport tableelement, existing records in the target table are updated (modify path), so  the "OnBeforeInsertRecord" that validates the No. was skipped and Fixed Field Name was left unpopulated.